### PR TITLE
Rename the two "query" commands to "show"

### DIFF
--- a/lib/chef/knife/vsphere_pool_query.rb
+++ b/lib/chef/knife/vsphere_pool_query.rb
@@ -8,51 +8,11 @@ class Chef::Knife::VspherePoolQuery < Chef::Knife::BaseVsphereCommand
 
   common_options
 
-  def traverse_folders_for_pool(folder, poolname)
-    children = folder.children.find_all
-    children.each do |child|
-      if child.class == RbVmomi::VIM::ClusterComputeResource || child.class == RbVmomi::VIM::ComputeResource || child.class == RbVmomi::VIM::ResourcePool
-        return child if child.name == poolname
-      elsif child.class == RbVmomi::VIM::Folder
-        pool = traverse_folders_for_pool(child, poolname)
-        return pool if pool
-      end
-    end
-    false
-  end
-
   def run
-    $stdout.sync = true
-    poolname = @name_args[0]
-    if poolname.nil?
-      show_usage
-      fatal_exit('You must specify a resource poor or cluster name (see knife vsphere pool list)')
-    end
-
-    query_string = @name_args[1]
-    if query_string.nil?
-      show_usage
-      fatal_exit('You must specify a QUERY value (e.g. summary.overallStatus )')
-    end
-
-    vim_connection
-
-    dc = datacenter
-    folder = dc.hostFolder
-
-    pool = traverse_folders_for_pool(folder, poolname) || abort("Pool #{poolname} not found")
-
-    # split QUERY by dots, and walk the object model
-    query = query_string.split '.'
-    result = pool
-    query.each do |part|
-      message, index = part.split(/[\[\]]/)
-      unless result.respond_to? message.to_sym
-        fatal_exit("\"#{query_string}\" not recognized.")
-      end
-
-      result = index ? result.send(message)[index.to_i] : result.send(message)
-    end
-    puts result
+    args = ARGV
+    args[2] = 'show'
+    ui.warn 'vsphere pool query is moving to vsphere pool show. Next time, please run'
+    ui.warn args.join " "
+    Chef::Knife.run(args)
   end
 end

--- a/lib/chef/knife/vsphere_pool_show.rb
+++ b/lib/chef/knife/vsphere_pool_show.rb
@@ -1,0 +1,58 @@
+require 'chef/knife'
+require 'chef/knife/base_vsphere_command'
+require 'rbvmomi'
+require 'netaddr'
+
+class Chef::Knife::VspherePoolShow < Chef::Knife::BaseVsphereCommand
+  banner "knife vsphere pool show POOLNAME QUERY.  See \"http://pubs.vmware.com/vi3/sdk/ReferenceGuide/vim.ComputeResource.html\" for allowed QUERY values."
+
+  common_options
+
+  def traverse_folders_for_pool(folder, poolname)
+    children = folder.children.find_all
+    children.each do |child|
+      if child.class == RbVmomi::VIM::ClusterComputeResource || child.class == RbVmomi::VIM::ComputeResource || child.class == RbVmomi::VIM::ResourcePool
+        return child if child.name == poolname
+      elsif child.class == RbVmomi::VIM::Folder
+        pool = traverse_folders_for_pool(child, poolname)
+        return pool if pool
+      end
+    end
+    false
+  end
+
+  def run
+    $stdout.sync = true
+    poolname = @name_args[0]
+    if poolname.nil?
+      show_usage
+      fatal_exit('You must specify a resource poor or cluster name (see knife vsphere pool list)')
+    end
+
+    query_string = @name_args[1]
+    if query_string.nil?
+      show_usage
+      fatal_exit('You must specify a QUERY value (e.g. summary.overallStatus )')
+    end
+
+    vim_connection
+
+    dc = datacenter
+    folder = dc.hostFolder
+
+    pool = traverse_folders_for_pool(folder, poolname) || abort("Pool #{poolname} not found")
+
+    # split QUERY by dots, and walk the object model
+    query = query_string.split '.'
+    result = pool
+    query.each do |part|
+      message, index = part.split(/[\[\]]/)
+      unless result.respond_to? message.to_sym
+        fatal_exit("\"#{query_string}\" not recognized.")
+      end
+
+      result = index ? result.send(message)[index.to_i] : result.send(message)
+    end
+    puts result
+  end
+end

--- a/lib/chef/knife/vsphere_vm_query.rb
+++ b/lib/chef/knife/vsphere_vm_query.rb
@@ -1,6 +1,3 @@
-# Author:: Brian Dupras (<bdupras@rallydev.com>)
-# License:: Apache License, Version 2.0
-
 require 'chef/knife'
 require 'chef/knife/base_vsphere_command'
 require 'rbvmomi'
@@ -12,37 +9,10 @@ class Chef::Knife::VsphereVmQuery < Chef::Knife::BaseVsphereCommand
   common_options
 
   def run
-    $stdout.sync = true
-    vmname = @name_args[0]
-    if vmname.nil?
-      show_usage
-      fatal_exit('You must specify a virtual machine name')
-    end
-
-    query_string = @name_args[1]
-    if query_string.nil?
-      show_usage
-      fatal_exit('You must specify a QUERY value (e.g. guest.ipAddress or network[0].name)')
-    end
-
-    vim_connection
-
-    dc = datacenter
-    folder = find_folder(get_config(:folder)) || dc.vmFolder
-
-    vm = traverse_folders_for_vm(folder, vmname) || abort("VM #{vmname} not found")
-
-    # split QUERY by dots, and walk the object model
-    query = query_string.split '.'
-    result = vm
-    query.each do |part|
-      message, index = part.split(/[\[\]]/)
-      unless result.respond_to? message.to_sym
-        fatal_exit("\"#{query_string}\" not recognized.")
-      end
-
-      result = index ? result.send(message)[index.to_i] : result.send(message)
-    end
-    puts result
+    args = ARGV
+    args[2] = 'show'
+    ui.warn 'vsphere vm query is moving to vsphere vm show. Next time, please run'
+    ui.warn args.join " "
+    Chef::Knife.run(args)
   end
 end

--- a/lib/chef/knife/vsphere_vm_show.rb
+++ b/lib/chef/knife/vsphere_vm_show.rb
@@ -1,0 +1,48 @@
+# Author:: Brian Dupras (<bdupras@rallydev.com>)
+# License:: Apache License, Version 2.0
+
+require 'chef/knife'
+require 'chef/knife/base_vsphere_command'
+require 'rbvmomi'
+require 'netaddr'
+
+class Chef::Knife::VsphereVmShow < Chef::Knife::BaseVsphereCommand
+  banner "knife vsphere vm show VMNAME QUERY.  See \"http://pubs.vmware.com/vi3/sdk/ReferenceGuide/vim.VirtualMachine.html\" for allowed QUERY values."
+
+  common_options
+
+  def run
+    $stdout.sync = true
+    vmname = @name_args[0]
+    if vmname.nil?
+      show_usage
+      fatal_exit('You must specify a virtual machine name')
+    end
+
+    query_string = @name_args[1]
+    if query_string.nil?
+      show_usage
+      fatal_exit('You must specify a QUERY value (e.g. guest.ipAddress or network[0].name)')
+    end
+
+    vim_connection
+
+    dc = datacenter
+    folder = find_folder(get_config(:folder)) || dc.vmFolder
+
+    vm = traverse_folders_for_vm(folder, vmname) || abort("VM #{vmname} not found")
+
+    # split QUERY by dots, and walk the object model
+    query = query_string.split '.'
+    result = vm
+    query.each do |part|
+      message, index = part.split(/[\[\]]/)
+      unless result.respond_to? message.to_sym
+        fatal_exit("\"#{query_string}\" not recognized.")
+      end
+
+      result = index ? result.send(message)[index.to_i] : result.send(message)
+    end
+    puts result
+  end
+end


### PR DESCRIPTION
Still provides the original commands by re-invoking knife with the new
way of doing things if it's called the old way.

While we are querying values on the vm and pool, other knife commands
all use "show" instead of "query", so this is an attempt to conform.