### PR TITLE
Fixed issue with multiple VLANs

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -437,7 +437,10 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
       fatal_exit "No hosts have the requested DatastoreCluster available! #{get_config(:datastorecluster)}" if hosts.empty?
 
       if get_config(:customization_vlan)
-        hosts.reject! { |host| !host.network.include?(find_network(get_config(:customization_vlan))) }
+        vlan_list = get_config(:customization_vlan).split(',')
+        vlan_list.each do |network|
+          hosts.reject! { |host| !host.network.include?(find_network(network)) }
+        end
       end
 
       fatal_exit "No hosts have the requested Network available! #{get_config(:customization_vlan)}" if hosts.empty?


### PR DESCRIPTION
When multiple VLANs are specified the script does not split the provided name and it uses the whole string to check if that VLAN exists (e.g. using "--cvlan Vnet-01,Vnet-02" will return an error stating that "Vnet-01,Vnet02" does not exist).

The proposed change fixes this behavior: the script now checks if every specified VLAN exists in the Datacenter.