### PR TITLE
cast String value to an Integer: sysprep-timeout

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -345,7 +345,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
       unless config[:disable_customization]
         # Wait for customization to complete
         puts 'Waiting for customization to complete...'
-        CustomizationHelper.wait_for_sysprep(vm, vim, get_config(:sysprep_timeout), 10)
+        CustomizationHelper.wait_for_sysprep(vm, vim, Integer(get_config(:sysprep_timeout)), 10)
         puts 'Customization Complete'
         sleep 2 until vm.guest.ipAddress
         connect_host = config[:fqdn] = config[:fqdn] ? get_config(:fqdn) : vm.guest.ipAddress


### PR DESCRIPTION
When passing in a value for --sysprep-timeout, vsphere_vm_clone.rb does not cast to a number.  The comparison at customization_helper.rb:24 then fails, as the value for 'timeout' is a String, not an Integer.