### PR TITLE
Let get_config accept a value of false

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    knife-vsphere (1.2.8)
+    knife-vsphere (1.2.9)
       filesize (~> 0.1.1)
       knife-windows (~> 1.0)
       netaddr (~> 1.5)

--- a/lib/chef/knife/base_vsphere_command.rb
+++ b/lib/chef/knife/base_vsphere_command.rb
@@ -78,7 +78,7 @@ class Chef
 
       def get_config(key)
         key = key.to_sym
-        rval = config[key] || Chef::Config[:knife][key]
+        rval = config[key].nil? ? Chef::Config[:knife][key] : config[key]
         Chef::Log.debug("value for config item #{key}: #{rval}")
         rval
       end

--- a/lib/chef/knife/vsphere_vm_snapshot.rb
+++ b/lib/chef/knife/vsphere_vm_snapshot.rb
@@ -50,11 +50,13 @@ class Chef::Knife::VsphereVmSnapshot < Chef::Knife::BaseVsphereCommand
 
   option :dump_memory,
          long: '--dump-memory',
+         boolean: true,
          description: 'Dump the memory in the snapshot',
          default: false
 
   option :quiesce,
          long: '--quiesce',
+         boolean: true,
          description: 'Quiesce the VM prior to snapshotting',
          default: false
 


### PR DESCRIPTION
get_config checks in both the config hash and the Chef::Config hash for
the given option. Why? I'm not sure, but it's there. It uses the
traditional `val = a || b`, so that if a is nil then the value of b is
used. But if a is intentionally false, it still chooses b because both
are falsey.