### PR TITLE
Add clone/bootstrap options.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@ knife-vsphere changelog
 ----------------------
 
 1.2.10  swalberg - Fix get_config to allow falsey values
+        rhass    - Add clone/bootstrap option to allow choosing NIC when
+                   more than one NIC is configured in the source template
+                   or VM.
+        rhass    - Add clone/bootsrap option to force the use of IPv4 addresses
 
 1.2.9   swalberg - Bump knife-windows to fix gem conflict with em-winrm
 				         - Handle missing VM case in vmdk add

--- a/README.rdoc
+++ b/README.rdoc
@@ -180,6 +180,9 @@ Enumerates the customization specifications registered in the target datacenter.
    --json-attributes - A JSON string to be added to the first run of chef-client
    --disable-customization - Disable default customization
    --sysprep_timeout TIMEOUT - Wait TIMEOUT seconds for sysprep event before continuing with bootstrap
+   --bootstrap-ipv4 - Force using an IPv4 address when a NIC has both IPv4 and IPv6 addresses.
+   --bootstrap-nic INTEGER - Network interface to use when multiple NICs are defined on a template.
+
 
 Clones an existing VM template into a new VM instance, optionally applying an existing customization specification.  If customization arguments such as --chost and --cdomain are specified, or if the customization sepcification fetched from VSphere is considered, a default customization specification will be attempted.  For windows, a sysprep based unattended customization in workgroup mode will be attempted (host name being the VM name unless otherwise specified).  For linux, a fixed named customization using the vmname as the host name unless otherwise specified.  These customization specification defaults can be disabled using the --disable-customization switch and the --cspec specified as-is.
 

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -376,7 +376,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     # address is assigned. As such, we need to wait until a routable IP address
     # becomes available. This is most commonly an issue with Windows instances.
     sleep 2 while vm.guest.net[config[:bootstrap_nic]].ipConfig.ipAddress.detect { |addr| IPAddr.new(addr.ipAddress).ipv4? }.origin == 'linklayer'
-    vm.guest.net[config[:bootstrap_nic]].ipConfig.ipAddress.detect { |addr| IPAddr.new(addr.ipAddress).ipv4? }.ipAddress
+    vm.guest.net[config[:bootstrap_nic]].ipAddress.detect { |addr| IPAddr.new(addr).ipv4? }
   end
 
   def guest_address(vm)

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -3,6 +3,7 @@
 # Contributor:: Jesse Campbell (<hikeit@gmail.com>)
 # Contributor:: Bethany Erskine (<bethany@paperlesspost.com>)
 # Contributor:: Adrian Stanila (https://github.com/sacx)
+# Contributor:: Ryan Hass (rhass@chef.io)
 # License:: Apache License, Version 2.0
 #
 
@@ -13,6 +14,7 @@ require 'netaddr'
 require 'securerandom'
 require 'chef/knife/winrm_base'
 require 'chef/knife/customization_helper'
+require 'ipaddr'
 
 # Clone an existing template into a new VM, optionally applying a customization specification.
 # usage:
@@ -282,6 +284,16 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
          description: 'Wait TIMEOUT seconds for sysprep event before continuing with bootstrap',
          default: 600
 
+  option :bootstrap_nic,
+         long: '--bootstrap-nic INTEGER',
+         description: 'Network interface to use when multiple NICs are defined on a template.',
+         default: 0
+
+  option :bootstrap_ipv4,
+         long: '--bootstrap-ipv4',
+         description: 'Force using an IPv4 address when a NIC has both IPv4 and IPv6 addresses.',
+         default: false
+
   def run
     $stdout.sync = true
 
@@ -332,9 +344,8 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     end
 
     return unless get_config(:bootstrap)
-    sleep 2 until vm.guest.ipAddress
 
-    connect_host = config[:fqdn] = config[:fqdn] ? get_config(:fqdn) : vm.guest.ipAddress
+    connect_host = guest_address(vm)
     Chef::Log.debug("Connect Host for Bootstrap: #{connect_host}")
     connect_port = get_config(:ssh_port)
     protocol = get_config(:bootstrap_protocol)
@@ -347,8 +358,6 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
         puts 'Waiting for customization to complete...'
         CustomizationHelper.wait_for_sysprep(vm, vim, Integer(get_config(:sysprep_timeout)), 10)
         puts 'Customization Complete'
-        sleep 2 until vm.guest.ipAddress
-        connect_host = config[:fqdn] = config[:fqdn] ? get_config(:fqdn) : vm.guest.ipAddress
       end
       wait_for_access(connect_host, connect_port, protocol)
       ssh_override_winrm
@@ -359,6 +368,33 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
       ssh_override_winrm
       bootstrap_for_node.run
     end
+  end
+
+  def ipv4_address(vm)
+    puts 'Waiting for a valid IPv4 address...'
+    # Multiple reboots occur during guest customization in which a link-local
+    # address is assigned. As such, we need to wait until a routable IP address
+    # becomes available. This is most commonly an issue with Windows instances.
+    sleep 2 while vm.guest.net[config[:bootstrap_nic]].ipConfig.ipAddress.detect { |addr| IPAddr.new(addr.ipAddress).ipv4? }.origin == 'linklayer'
+    vm.guest.net[config[:bootstrap_nic]].ipConfig.ipAddress.detect { |addr| IPAddr.new(addr.ipAddress).ipv4? }.ipAddress
+  end
+
+  def guest_address(vm)
+    puts 'Waiting for network interfaces to become available...'
+    sleep 2 while vm.guest.net.empty? && !vm.guest.ipAddress
+    guest_address ||=
+      config[:fqdn] = if config[:bootstrap_ipv4]
+                        ipv4_address(vm)
+                      elsif config[:fqdn]
+                        get_config(:fqdn)
+                      else
+                        # Use the first IP which is not a link-local address.
+                        # This is the closest thing to vm.guest.ipAddress but
+                        # allows specifying a NIC.
+                        vm.guest.net[config[:bootstrap_nic]].ipConfig.ipAddress.detect do |addr|
+                          addr.origin != 'linklayer'
+                        end.ipAddress
+                      end
   end
 
   def wait_for_access(connect_host, connect_port, protocol)


### PR DESCRIPTION
This adds two new options for clone/bootstrap.

- `--bootstrap-nic [INTEGER]` allows a user to specify a specific
  network interface to use when the source template or VM has more
  than one adapter defined. This defaults to the first adapter
  available.
- `--bootstrap-ipv4` allows a user to force the use of an IPv4 address
  while bootstrapping the instance. This is useful when IPv6 networks
  are not routable and/or when Windows instances come up with link-local
  addresses which are not accessible.