### PR TITLE
clone: Fix waiting for address conditional

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -381,7 +381,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
 
   def guest_address(vm)
     puts 'Waiting for network interfaces to become available...'
-    sleep 2 while vm.guest.net.empty? && !vm.guest.ipAddress
+    sleep 2 while vm.guest.net.empty? || !vm.guest.ipAddress
     guest_address ||=
       config[:fqdn] = if config[:bootstrap_ipv4]
                         ipv4_address(vm)


### PR DESCRIPTION
Currently the wait condition for the availability of IP addresses is an
and (&&) condition on both vm.guest.net.empty? and !vm.guest.ipAddress,
however this can lead to a race condition where rbvmomi will see the IP
address returned by vsphere before it has the full NIC information,
leading to a NilClass issue in later parts of the logic. I'd imagine
that the intention here was to wait for both to pass, so this needs to
be changed to an or (||).