### PR TITLE
Added ability to list all of a VM's IPS and their associated networks

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -102,14 +102,15 @@ FIELDS:
     --esx-disk                   Show esx disks
     --full-path                  Show full path
     --hostname                   show hostname
-    --ip                         Show ip
-    --os                         show os details
+    --ip                         Show primary ip
+    --ips                        Show all ips assigned to VM with network (format: VLAN1:IP1,VLAN2:IP2)
+    --os                         Show os details
     --os-disks                   Show os disks
     --ram                        Show ram
     --snapshots                  Show snapshots
     --tools                      show tools status
 
-     knife vsphere vm find --snapshots --full-path --pool XXX-YYYY --cpu --ram --esx-disk --os-disk --os --match-name my_machine_1 --alarms --tools --ip --match-ip 123 --match-tools toolsOk
+     knife vsphere vm find --snapshots --full-path --pool XXX-YYYY --cpu --ram --esx-disk --os-disk --os --match-name my_machine_1 --alarms --tools --ip --ips --match-ip 123 --match-tools toolsOk
 
 == knife vsphere vm state [-s STATE, --state STATE] [-w PORT, --wait-port PORT] [-g, --shutdown] [-r, --recursive]
 

--- a/lib/chef/knife/vsphere_vm_find.rb
+++ b/lib/chef/knife/vsphere_vm_find.rb
@@ -45,7 +45,11 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
 
   option :ip,
          long: '--ip',
-         description: 'Show ip'
+         description: 'Show primary ip'
+
+  option :ips,
+	 long: '--ips',
+	 description: 'Show all ips, with vlans'
 
   option :soff,
          long: '--powered-off',
@@ -188,6 +192,10 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
 
        if get_config(:ip)
          print "#{ui.color("IP:", :cyan)} #{vmc.guest.ipAddress}\t"
+       end
+       if get_config(:ips)
+         networks = vmc.guest.net.map { |net| net.network + ":" + net.ipAddress.select{ |i| i[/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/]}[0] }.join(",")
+	 print "#{ui.color("IPS:", :cyan)} #{networks}\t"
        end
        if get_config(:os)
          print "#{ui.color("OS:", :cyan)} #{vmc.guest.guestFullName}\t"

--- a/lib/chef/knife/vsphere_vm_find.rb
+++ b/lib/chef/knife/vsphere_vm_find.rb
@@ -194,7 +194,7 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
          print "#{ui.color("IP:", :cyan)} #{vmc.guest.ipAddress}\t"
        end
        if get_config(:ips)
-         networks = vmc.guest.net.map { |net| net.network + ":" + net.ipAddress.select{ |i| i[/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/]}[0] }.join(",")
+         networks = vmc.guest.net.map { |net| net.network + ":" + net.ipAddress.select { |i| i[/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/] }[0] }.join(",")
 	 print "#{ui.color("IPS:", :cyan)} #{networks}\t"
        end
        if get_config(:os)

--- a/lib/chef/knife/vsphere_vm_find.rb
+++ b/lib/chef/knife/vsphere_vm_find.rb
@@ -194,9 +194,9 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
          print "#{ui.color("IP:", :cyan)} #{vmc.guest.ipAddress}\t"
        end
        if get_config(:ips)
-        ipregex = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/ 
-        networks = vmc.guest.net.map { |net| net.network + ":" + net.ipConfig.ipAddress.select { |i| i.ipAddress[ipregex] }[0].ipAddress }
-        print "#{ui.color("IPS:", :cyan)} #{networks.join(",")}\t"
+         ipregex = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/
+         networks = vmc.guest.net.map { |net| "#{net.network}:" + net.ipConfig.ipAddress.select { |i| i.ipAddress[ipregex] }[0].ipAddress }
+         print "#{ui.color("IPS:", :cyan)} #{networks.join(",")}\t"
        end
        if get_config(:os)
          print "#{ui.color("OS:", :cyan)} #{vmc.guest.guestFullName}\t"

--- a/lib/chef/knife/vsphere_vm_find.rb
+++ b/lib/chef/knife/vsphere_vm_find.rb
@@ -48,8 +48,8 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
          description: 'Show primary ip'
 
   option :ips,
-	 long: '--ips',
-	 description: 'Show all ips, with vlans'
+         long: '--ips',
+         description: 'Show all ips, with networks'
 
   option :soff,
          long: '--powered-off',
@@ -194,7 +194,7 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
          print "#{ui.color("IP:", :cyan)} #{vmc.guest.ipAddress}\t"
        end
        if get_config(:ips)
-         networks = vmc.guest.net.map { |net| net.network + ":" + net.ipAddress.select { |i| i[/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/] }[0] }.join(",")
+         networks = vmc.guest.net.map { |net| net.network + ":" + net.ipConfig.ipAddress.select { |i| i.ipAddress[/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/] }[0].ipAddress }.join(",") 
 	 print "#{ui.color("IPS:", :cyan)} #{networks}\t"
        end
        if get_config(:os)

--- a/lib/chef/knife/vsphere_vm_find.rb
+++ b/lib/chef/knife/vsphere_vm_find.rb
@@ -194,8 +194,9 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
          print "#{ui.color("IP:", :cyan)} #{vmc.guest.ipAddress}\t"
        end
        if get_config(:ips)
-         networks = vmc.guest.net.map { |net| net.network + ":" + net.ipConfig.ipAddress.select { |i| i.ipAddress[/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/] }[0].ipAddress }.join(",") 
-	 print "#{ui.color("IPS:", :cyan)} #{networks}\t"
+        ipregex = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/ 
+        networks = vmc.guest.net.map { |net| net.network + ":" + net.ipConfig.ipAddress.select { |i| i.ipAddress[ipregex] }[0].ipAddress }
+        print "#{ui.color("IPS:", :cyan)} #{networks.join(",")}\t"
        end
        if get_config(:os)
          print "#{ui.color("OS:", :cyan)} #{vmc.guest.guestFullName}\t"


### PR DESCRIPTION
On multi-homed machines, only one of the IPs is displayed, and sometimes it's not the primary address. This PR gives the ability to display all IP addresses associated with a VM along with their networks.