### PR TITLE
Add --cmac and --sw-uuid command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,13 @@ datacenter. Only name is currently displayed.
     --resource-pool POOL|CLUSTER - The resource pool into which to put the cloned VM. Also accepts a cluster name.
     --template TEMPLATE - The source VM / Template to clone from
     --cspec CUST_SPEC - The name of any customization specification to apply
+    --sw-uuid SWITCH_UUIDS - Comma-delimited list of virtual switch UUIDs to attach to the network adapters, or *auto* to automatically assign virtual switch
     --disable-customization FALSE - by default conventions will be applied to the customization specification (see below).  Disable these convention with this switch
     --cplugin CUST_PLUGIN_PATH - Path to plugin that implements KnifeVspherePlugin.customize_clone_spec and/or KnifeVspherePlugin.reconfig_vm
     --cplugin-data CUST_PLUGIN_DATA - String of data to pass to the plugin.  Use any format you wish.
     --cvlan CUST_VLANS - Comma-delimited list of VLAN names for the network adapters to join
     --cips CUST_IPS - Comma-delimited list of CIDR IPs for customization, or *dhcp* to configure that interface to use DHCP
+    --cmac CUST_MACS - Comma-delimited list of MAC addresses, or *auto* to configure that interface to use automatically generated MAC address
     --cgw CUST_GW - CIDR IP of gateway for customization
     --chostname CUST_HOSTNAME - Unqualified hostname for customization
     --cdomain CUST_DOMAIN - Domain name for customization

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -339,7 +339,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     puts "Finished creating virtual machine #{vmname}"
 
     if customization_plugin && customization_plugin.respond_to?(:reconfig_vm)
-      target_vm = find_in_folder(dest_folder, RbVmomi::VIM::VirtualMachine, vmname) || abort("VM could not be found in #{dest_folder}")  
+      target_vm = find_in_folder(dest_folder, RbVmomi::VIM::VirtualMachine, vmname) || abort("VM could not be found in #{dest_folder}")
       customization_plugin.reconfig_vm(target_vm)
     end
 


### PR DESCRIPTION
In a 1.0.17 version of this code, or some code that was branched from it long ago, one could specify MAC address and virtual switch UUID for the primary interface with --cmac and -sw-uuid.  That version does not exist in version control anywhere, and it only worked for the primary interface.

We want to use the newer features to support multiple interfaces, but require those options, so I made an attempt to add them in similar fashion to how this old code did it, while preserving the new features.

Intended design:

--cmac MACs
Accepts a comma-separated list of MAC addresses to assign to the interfaces, any MAC address can be replaced with the word 'auto' to automatically assign a MAC that interface.  Or you can omit --cmac and it will work as before.

--sw-uuid UUIDs
Accepts a comma-separated list of virtual switch UUIDs to assign interfaces to, any UUID can be replaced with the word 'auto' to automatically assign a UUID to that interface, or drop back to the non-virtual-switch case.  Or you can omit --sw-uuid and it will work as before.  

The way I implemented it, it requires you to supply --cips if you supply --cmac, and requires you to supply --cvlan if you supply --sw-uuid, because the easiest mode of implementation was to assign these things in the sections of code used for vlans and IPs, that is how my really old version of code did it.  I am entirely open to doing it differently, but we want to have a starting point for discussion.

My first public pull request, so looking forward to advice from my betters.  :->