### PR TITLE
Make sure we specified mac addresses before accessing array of mac ad…

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -578,7 +578,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
           # not connected to a distibuted switch?
           card.backing = RbVmomi::VIM::VirtualEthernetCardNetworkBackingInfo(network: network, deviceName: network.name)
         end
-        card.macAddress = mac_list[index] if mac_list[index] != 'auto'
+        card.macAddress = mac_list[index] if get_config(:customization_macs) && mac_list[index] != 'auto'
         dev_spec = RbVmomi::VIM.VirtualDeviceConfigSpec(device: card, operation: 'edit')
         clone_spec.config.deviceChange.push dev_spec
       end


### PR DESCRIPTION
…dresses

We just need to make sure that MAC addresses were specified at all before attempting to access the array of specified MACs.