### PR TITLE
Refactor

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use chefdk
+

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ These options are related to the customization of the VM by the vSphere agent. T
 --cspec CUST_SPEC - The name of any customization specifications that are defined in vCenter to apply
 --ctz CUST_TIMEZONE - Timezone in valid 'Area/Location' format
 --cvlan CUST_VLANS - Comma-delimited list of VLAN names for the network adapters to join
---disable-customization - By default conventions will be applied to the customization specification (see below).  Disable these convention with this switch
+--disable-customization - By default customizations will be applied to the customization specification (see below).  Disable these convention with this switch
 --random-vmname - Creates a random VMNAME starts with vm-XXXXXXXX
 --random-vmname-prefix - Change the VMNAME prefix
 ```
@@ -320,7 +320,8 @@ $ knife vsphere vm clone NewNode --template UbuntuTemplate --cspec StaticSpec \
 ```
 
 The customization specification defaults can be disabled using the
-`--disable-customization` switch and the `--cspec` specified as-is.
+`--disable-customization` switch. If you specify a `--cspec` with this option,
+that spec will still be applied.
 
 NOTE: if you are specifying a `--cspec` and the cloning process appears to not
 be properly applying the spec as defined on vSphere, consider using the

--- a/knife-vsphere.gemspec
+++ b/knife-vsphere.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('chef', ['>= 0.10.0'])
   s.add_development_dependency('rspec')
   s.add_development_dependency('rake')
+  s.add_development_dependency('byebug')
 end

--- a/lib/chef/knife/base_vsphere_command.rb
+++ b/lib/chef/knife/base_vsphere_command.rb
@@ -373,6 +373,7 @@ class Chef
       def linux?(config)
         gid = config.guestId.downcase
         # This makes the assumption that if it isn't mac or windows it's linux
+        # See https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html for values
         is_linux_bool = !gid.include?('windows') && !gid.include?('darwin')
         Chef::Log.debug('Identified os as linux.') if is_linux_bool
         is_linux_bool

--- a/lib/chef/knife/base_vsphere_command.rb
+++ b/lib/chef/knife/base_vsphere_command.rb
@@ -110,7 +110,7 @@ class Chef
       end
 
       def vim_connection
-        config[:vim] = RbVmomi::VIM.connect conn_opts
+        config[:vim] ||= RbVmomi::VIM.connect conn_opts
       end
 
       def get_password_from_stdin
@@ -183,7 +183,7 @@ class Chef
 
       def datacenter
         dcname = get_config(:vsphere_dc)
-        traverse_folders_for_dc(config[:vim].rootFolder, dcname) || abort('datacenter not found')
+        traverse_folders_for_dc(vim_connection.rootFolder, dcname) || abort('datacenter not found')
       end
 
       def find_folder(folderName)

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -499,15 +499,14 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
 
   # Builds a CloneSpec
   def generate_clone_spec(src_config)
-    rspec = nil
-    if get_config(:resource_pool)
-      rspec = RbVmomi::VIM.VirtualMachineRelocateSpec(pool: find_pool(get_config(:resource_pool)))
-    else
-      hosts = find_available_hosts
+    rspec = RbVmomi::VIM.VirtualMachineRelocateSpec
 
-      rp = hosts.first.resourcePool
-      rspec = RbVmomi::VIM.VirtualMachineRelocateSpec(pool: rp)
-    end
+    rspec.pool = if get_config(:resource_pool)
+                   find_pool(get_config(:resource_pool))
+                 else
+                   hosts = find_available_hosts
+                   hosts.first.resourcePool
+                 end
 
     if get_config(:linked_clone)
       rspec.diskMoveType = :moveChildMostDiskBacking
@@ -529,7 +528,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     end
 
     if get_config(:thin_provision)
-      rspec = RbVmomi::VIM.VirtualMachineRelocateSpec(transform: :sparse, pool: find_pool(get_config(:resource_pool)))
+      rspec.transform = :sparse
     end
 
     is_template = !get_config(:mark_as_template).nil?

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -402,19 +402,18 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     puts 'Waiting for network interfaces to become available...'
     sleep 2 while vm.guest.net.empty? || !vm.guest.ipAddress
     ui.info "Found address #{vm.guest.ipAddress}" if log_verbose?
-    guest_address ||=
-      config[:fqdn] = if config[:bootstrap_ipv4]
-                        ipv4_address(vm)
-                      elsif config[:fqdn]
-                        get_config(:fqdn)
-                      else
-                        # Use the first IP which is not a link-local address.
-                        # This is the closest thing to vm.guest.ipAddress but
-                        # allows specifying a NIC.
-                        vm.guest.net[bootstrap_nic_index].ipConfig.ipAddress.detect do |addr|
-                          addr.origin != 'linklayer'
-                        end.ipAddress
-                      end
+    config[:fqdn] = if config[:bootstrap_ipv4]
+                      ipv4_address(vm)
+                    elsif config[:fqdn]
+                      get_config(:fqdn)
+                    else
+                      # Use the first IP which is not a link-local address.
+                      # This is the closest thing to vm.guest.ipAddress but
+                      # allows specifying a NIC.
+                      vm.guest.net[bootstrap_nic_index].ipConfig.ipAddress.detect do |addr|
+                        addr.origin != 'linklayer'
+                      end.ipAddress
+                    end
   end
 
   def wait_for_access(connect_host, connect_port, protocol)
@@ -424,7 +423,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
         config[:winrm_port] = '5986'
       end
       connect_port = get_config(:winrm_port)
-      print "\n#{ui.color("Waiting for winrm access to become available on #{connect_host}:#{connect_port}",:magenta)}"
+      print "\n#{ui.color("Waiting for winrm access to become available on #{connect_host}:#{connect_port}", :magenta)}"
       print('.') until tcp_test_winrm(connect_host, connect_port) do
         sleep 10
         puts('done')
@@ -503,10 +502,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
                    hosts.first.resourcePool
                  end
 
-    if get_config(:linked_clone)
-      rspec.diskMoveType = :moveChildMostDiskBacking
-    end
-
+    rspec.diskMoveType = :moveChildMostDiskBacking if get_config(:linked_clone)
 
     if get_config(:datastore)
       rspec.datastore = find_datastore(get_config(:datastore))
@@ -522,9 +518,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
       end
     end
 
-    if get_config(:thin_provision)
-      rspec.transform = :sparse
-    end
+    rspec.transform = :sparse if get_config(:thin_provision)
 
     is_template = !get_config(:mark_as_template).nil?
     clone_spec = RbVmomi::VIM.VirtualMachineCloneSpec(location: rspec, powerOn: false, template: is_template)
@@ -685,7 +679,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     clone_spec
   end
 
-# Loads the customization plugin if one was specified
+  # Loads the customization plugin if one was specified
   # @return [KnifeVspherePlugin] the loaded and initialized plugin or nil
   def customization_plugin
     if @customization_plugin.nil?

--- a/lib/chef/knife/vsphere_vm_find.rb
+++ b/lib/chef/knife/vsphere_vm_find.rb
@@ -8,9 +8,9 @@ require 'chef/knife/base_vsphere_command'
 require 'rbvmomi'
 require 'netaddr'
 
-PS_ON = 'poweredOn'
-PS_OFF = 'poweredOff'
-PS_SUSPENDED = 'suspended'
+PS_ON = 'poweredOn'.freeze
+PS_OFF = 'poweredOff'.freeze
+PS_SUSPENDED = 'suspended'.freeze
 
 # find vms belonging to pool that match criteria, display specified fields
 class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
@@ -103,10 +103,8 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
       next unless child.class == RbVmomi::VIM::ClusterComputeResource || child.class == RbVmomi::VIM::ComputeResource || child.class == RbVmomi::VIM::ResourcePool
       if child.name == poolname
         return child
-      else
-        if child.class == RbVmomi::VIM::Folder || child.class == RbVmomi::VIM::ComputeResource || child.class == RbVmomi::VIM::ClusterComputeResource || child.class == RbVmomi::VIM::ResourcePool
-          pool = traverse_folders_for_pool_clustercompute(child, poolname)
-        end
+      elsif child.class == RbVmomi::VIM::Folder || child.class == RbVmomi::VIM::ComputeResource || child.class == RbVmomi::VIM::ClusterComputeResource || child.class == RbVmomi::VIM::ResourcePool
+        pool = traverse_folders_for_pool_clustercompute(child, poolname)
       end
       return pool if pool
     end
@@ -126,11 +124,11 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
 
     pool = traverse_folders_for_pool_clustercompute(folder, poolname) || abort("Pool #{poolname} not found")
 
-    if pool.class == RbVmomi::VIM::ResourcePool
-      vm = pool.vm
-    else
-      vm = pool.resourcePool.vm
-    end
+    vm = if pool.class == RbVmomi::VIM::ResourcePool
+           pool.vm
+         else
+           pool.resourcePool.vm
+         end
 
     return if vm.nil?
     vm.each do |vmc|
@@ -181,8 +179,8 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
           actualname.concat("#{vmcp.parent.name}/")
           vmcp = vmcp.parent
         end
-        print "#{ui.color('Folder:', :cyan)}"
-        print "\""
+        print ui.color('Folder:', :cyan)
+        print '"'
         print actualname.split('/').reverse.join('/')
         print "\"\t"
 
@@ -216,7 +214,7 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
       end
 
       if get_config(:os_disk)
-        print "#{ui.color('OS Disks:', :cyan)}"
+        print ui.color('OS Disks:', :cyan)
         vmc.guest.disk.each do |disc|
           print "#{disc.diskPath} #{disc.capacity / 1024 / 1024}MB Free:#{disc.freeSpace / 1024 / 1024}MB |"
         end

--- a/lib/chef/knife/vsphere_vm_find.rb
+++ b/lib/chef/knife/vsphere_vm_find.rb
@@ -124,7 +124,7 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
     dc = datacenter
     folder = dc.hostFolder
 
-    pool = traverse_folders_for_pool_clustercompute(folder, poolname) || abort "Pool #{poolname} not found"
+    pool = traverse_folders_for_pool_clustercompute(folder, poolname) || abort("Pool #{poolname} not found")
 
     if pool.class == RbVmomi::VIM::ResourcePool
       vm = pool.vm

--- a/lib/chef/knife/vsphere_vm_find.rb
+++ b/lib/chef/knife/vsphere_vm_find.rb
@@ -95,22 +95,21 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
          long: '--full-path',
          description: 'Show full path'
 
-  $stdout.sync = true   # smoother output from print
+  $stdout.sync = true # smoother output from print
 
   def traverse_folders_for_pool_clustercompute(folder, poolname)
     # children = folder.children.find_all
     children = find_all_in_folder(folder, RbVmomi::VIM::ManagedObject)
     children.each do |child|
-      if child.class == RbVmomi::VIM::ClusterComputeResource || child.class == RbVmomi::VIM::ComputeResource || child.class == RbVmomi::VIM::ResourcePool
-        if child.name == poolname then return child
-         else if child.class == RbVmomi::VIM::Folder || child.class == RbVmomi::VIM::ComputeResource || child.class == RbVmomi::VIM::ClusterComputeResource || child.class == RbVmomi::VIM::ResourcePool
-                pool = traverse_folders_for_pool_clustercompute(child, poolname)
+      next unless child.class == RbVmomi::VIM::ClusterComputeResource || child.class == RbVmomi::VIM::ComputeResource || child.class == RbVmomi::VIM::ResourcePool
+      if child.name == poolname then return child
+      else if child.class == RbVmomi::VIM::Folder || child.class == RbVmomi::VIM::ComputeResource || child.class == RbVmomi::VIM::ClusterComputeResource || child.class == RbVmomi::VIM::ResourcePool
+             pool = traverse_folders_for_pool_clustercompute(child, poolname)
+                    end
               end
-        end
-        if pool then return pool end
-      end
+      return pool if pool
     end
-    return false
+    false
   end
 
   def run
@@ -134,110 +133,110 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
 
     unless vm.nil?
       vm.each do |vmc|
-       state = case vmc.runtime.powerState
-               when PsOn
-                 ui.color('on', :green)
-               when PsOff
-                 ui.color('off', :red)
-               when PsSuspended
-                 ui.color('suspended', :yellow)
-               end
+        state = case vmc.runtime.powerState
+                when PsOn
+                  ui.color('on', :green)
+                when PsOff
+                  ui.color('off', :red)
+                when PsSuspended
+                  ui.color('suspended', :yellow)
+                end
 
-       if get_config(:matchname)
-         next unless vmc.name.include? config[:matchname]
-       end
+        if get_config(:matchname)
+          next unless vmc.name.include? config[:matchname]
+        end
 
-       if get_config(:matchtools)
-         next unless vmc.guest.toolsStatus == config[:matchtools]
-       end
+        if get_config(:matchtools)
+          next unless vmc.guest.toolsStatus == config[:matchtools]
+        end
 
-       next if get_config(:soff) && (vmc.runtime.powerState == PsOn)
+        next if get_config(:soff) && (vmc.runtime.powerState == PsOn)
 
-       next if get_config(:son) && (vmc.runtime.powerState == PsOff)
+        next if get_config(:son) && (vmc.runtime.powerState == PsOff)
 
-       if get_config(:matchip)
-         if (!vmc.guest.ipAddress.nil? && vmc.guest.ipAddress != '')
-           next unless vmc.guest.ipAddress.include? config[:matchip]
-       else
-         next
-         end
-       end
+        if get_config(:matchip)
+          if !vmc.guest.ipAddress.nil? && vmc.guest.ipAddress != ''
+            next unless vmc.guest.ipAddress.include? config[:matchip]
+          else
+            next
+          end
+        end
 
-       unless vmc.guest.guestFullName.nil?
-         if get_config(:matchos)
-           next unless vmc.guest.guestFullName.include? config[:matchos]
-         end
-       end
+        unless vmc.guest.guestFullName.nil?
+          if get_config(:matchos)
+            next unless vmc.guest.guestFullName.include? config[:matchos]
+          end
+        end
 
-       print "#{ui.color("VM Name:", :cyan)} #{vmc.name}\t"
-       if get_config(:hostname)
-         print "#{ui.color("Hostname:", :cyan)} #{vmc.guest.hostName}\t"
-       end
+        print "#{ui.color('VM Name:', :cyan)} #{vmc.name}\t"
+        if get_config(:hostname)
+          print "#{ui.color('Hostname:', :cyan)} #{vmc.guest.hostName}\t"
+        end
 
-       if get_config(:full_path)
-         actualname = ''
-         vmcp = vmc
-         while vmcp.parent != nil && vmcp.parent.name != 'vm'
-           actualname.concat("#{vmcp.parent.name}/")
-           vmcp = vmcp.parent
-         end
-         print "#{ui.color("Folder:", :cyan)}"
-         print "\""
-         print actualname.split('/').reverse().join('/')
-         print "\"\t"
+        if get_config(:full_path)
+          actualname = ''
+          vmcp = vmc
+          while !vmcp.parent.nil? && vmcp.parent.name != 'vm'
+            actualname.concat("#{vmcp.parent.name}/")
+            vmcp = vmcp.parent
+          end
+          print "#{ui.color('Folder:', :cyan)}"
+          print "\""
+          print actualname.split('/').reverse.join('/')
+          print "\"\t"
 
-       else
-         print "#{ui.color("Folder", :cyan)}: #{vmc.parent.name}\t"
-       end
+        else
+          print "#{ui.color('Folder', :cyan)}: #{vmc.parent.name}\t"
+        end
 
-       if get_config(:ip)
-         print "#{ui.color("IP:", :cyan)} #{vmc.guest.ipAddress}\t"
-       end
-       if get_config(:ips)
-         ipregex = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/
-         networks = vmc.guest.net.map { |net| "#{net.network}:" + net.ipConfig.ipAddress.select { |i| i.ipAddress[ipregex] }[0].ipAddress }
-         print "#{ui.color("IPS:", :cyan)} #{networks.join(",")}\t"
-       end
-       if get_config(:os)
-         print "#{ui.color("OS:", :cyan)} #{vmc.guest.guestFullName}\t"
-       end
-       if get_config(:ram)
-         print "#{ui.color("RAM:", :cyan)} #{vmc.summary.config.memorySizeMB}\t"
-       end
-       if get_config(:cpu)
-         print "#{ui.color("CPU:", :cyan)} #{vmc.summary.config.numCpu}\t"
-       end
-       if get_config(:alarms)
-         print "#{ui.color("Alarms:", :cyan)} #{vmc.summary.overallStatus}\t"
-       end
-       print "#{ui.color("State:", :cyan)} #{state}\t"
-       if get_config(:tools)
-         print "#{ui.color("Tools:", :cyan)} #{vmc.guest.toolsStatus}\t"
-       end
+        if get_config(:ip)
+          print "#{ui.color('IP:', :cyan)} #{vmc.guest.ipAddress}\t"
+        end
+        if get_config(:ips)
+          ipregex = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/
+          networks = vmc.guest.net.map { |net| "#{net.network}:" + net.ipConfig.ipAddress.select { |i| i.ipAddress[ipregex] }[0].ipAddress }
+          print "#{ui.color('IPS:', :cyan)} #{networks.join(',')}\t"
+        end
+        if get_config(:os)
+          print "#{ui.color('OS:', :cyan)} #{vmc.guest.guestFullName}\t"
+        end
+        if get_config(:ram)
+          print "#{ui.color('RAM:', :cyan)} #{vmc.summary.config.memorySizeMB}\t"
+        end
+        if get_config(:cpu)
+          print "#{ui.color('CPU:', :cyan)} #{vmc.summary.config.numCpu}\t"
+        end
+        if get_config(:alarms)
+          print "#{ui.color('Alarms:', :cyan)} #{vmc.summary.overallStatus}\t"
+        end
+        print "#{ui.color('State:', :cyan)} #{state}\t"
+        if get_config(:tools)
+          print "#{ui.color('Tools:', :cyan)} #{vmc.guest.toolsStatus}\t"
+        end
 
-       if get_config(:os_disk)
-         print "#{ui.color("OS Disks:", :cyan)}"
-         vmc.guest.disk.each do |disc|
-           print "#{disc.diskPath} #{disc.capacity / 1024 / 1024}MB Free:#{disc.freeSpace / 1024 / 1024}MB |"
-         end
-       end
+        if get_config(:os_disk)
+          print "#{ui.color('OS Disks:', :cyan)}"
+          vmc.guest.disk.each do |disc|
+            print "#{disc.diskPath} #{disc.capacity / 1024 / 1024}MB Free:#{disc.freeSpace / 1024 / 1024}MB |"
+          end
+        end
 
-       if get_config(:esx_disk)
-         print "#{ui.color("ESX Disks:", :cyan)}"
-         vmc.layout.disk.each do |dsc|
-           print "#{dsc.diskFile} | "
-         end
-       end
+        if get_config(:esx_disk)
+          print "#{ui.color('ESX Disks:', :cyan)}"
+          vmc.layout.disk.each do |dsc|
+            print "#{dsc.diskFile} | "
+          end
+        end
 
-       if get_config(:snapshots)
-         unless vmc.snapshot.nil?
-           print "#{ui.color("Snapshots:", :cyan)}"
-           vmc.snapshot.rootSnapshotList.each do |snap|
-             print " #{snap.name}"
-           end
-         end
-       end
-       puts
+        if get_config(:snapshots)
+          unless vmc.snapshot.nil?
+            print "#{ui.color('Snapshots:', :cyan)}"
+            vmc.snapshot.rootSnapshotList.each do |snap|
+              print " #{snap.name}"
+            end
+          end
+        end
+        puts
       end
     end
   end

--- a/lib/chef/knife/vsphere_vm_find.rb
+++ b/lib/chef/knife/vsphere_vm_find.rb
@@ -8,9 +8,9 @@ require 'chef/knife/base_vsphere_command'
 require 'rbvmomi'
 require 'netaddr'
 
-PsOn = 'poweredOn'
-PsOff = 'poweredOff'
-PsSuspended = 'suspended'
+PS_ON = 'poweredOn'
+PS_OFF = 'poweredOff'
+PS_SUSPENDED = 'suspended'
 
 # find vms belonging to pool that match criteria, display specified fields
 class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
@@ -98,15 +98,16 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
   $stdout.sync = true # smoother output from print
 
   def traverse_folders_for_pool_clustercompute(folder, poolname)
-    # children = folder.children.find_all
     children = find_all_in_folder(folder, RbVmomi::VIM::ManagedObject)
     children.each do |child|
       next unless child.class == RbVmomi::VIM::ClusterComputeResource || child.class == RbVmomi::VIM::ComputeResource || child.class == RbVmomi::VIM::ResourcePool
-      if child.name == poolname then return child
-      else if child.class == RbVmomi::VIM::Folder || child.class == RbVmomi::VIM::ComputeResource || child.class == RbVmomi::VIM::ClusterComputeResource || child.class == RbVmomi::VIM::ResourcePool
-             pool = traverse_folders_for_pool_clustercompute(child, poolname)
-                    end
-              end
+      if child.name == poolname
+        return child
+      else
+        if child.class == RbVmomi::VIM::Folder || child.class == RbVmomi::VIM::ComputeResource || child.class == RbVmomi::VIM::ClusterComputeResource || child.class == RbVmomi::VIM::ResourcePool
+          pool = traverse_folders_for_pool_clustercompute(child, poolname)
+        end
+      end
       return pool if pool
     end
     false
@@ -119,11 +120,11 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
       fatal_exit('You must specify a resource pool or cluster name (see knife vsphere pool list)')
     end
 
-    vim = vim_connection
+    vim_connection
     dc = datacenter
     folder = dc.hostFolder
 
-    pool = traverse_folders_for_pool_clustercompute(folder, poolname) or abort "Pool #{poolname} not found"
+    pool = traverse_folders_for_pool_clustercompute(folder, poolname) || abort "Pool #{poolname} not found"
 
     if pool.class == RbVmomi::VIM::ResourcePool
       vm = pool.vm
@@ -131,113 +132,112 @@ class Chef::Knife::VsphereVmFind < Chef::Knife::BaseVsphereCommand
       vm = pool.resourcePool.vm
     end
 
-    unless vm.nil?
-      vm.each do |vmc|
-        state = case vmc.runtime.powerState
-                when PsOn
-                  ui.color('on', :green)
-                when PsOff
-                  ui.color('off', :red)
-                when PsSuspended
-                  ui.color('suspended', :yellow)
-                end
+    return if vm.nil?
+    vm.each do |vmc|
+      state = case vmc.runtime.powerState
+              when PS_ON
+                ui.color('on', :green)
+              when PS_OFF
+                ui.color('off', :red)
+              when PS_SUSPENDED
+                ui.color('suspended', :yellow)
+              end
 
-        if get_config(:matchname)
-          next unless vmc.name.include? config[:matchname]
-        end
-
-        if get_config(:matchtools)
-          next unless vmc.guest.toolsStatus == config[:matchtools]
-        end
-
-        next if get_config(:soff) && (vmc.runtime.powerState == PsOn)
-
-        next if get_config(:son) && (vmc.runtime.powerState == PsOff)
-
-        if get_config(:matchip)
-          if !vmc.guest.ipAddress.nil? && vmc.guest.ipAddress != ''
-            next unless vmc.guest.ipAddress.include? config[:matchip]
-          else
-            next
-          end
-        end
-
-        unless vmc.guest.guestFullName.nil?
-          if get_config(:matchos)
-            next unless vmc.guest.guestFullName.include? config[:matchos]
-          end
-        end
-
-        print "#{ui.color('VM Name:', :cyan)} #{vmc.name}\t"
-        if get_config(:hostname)
-          print "#{ui.color('Hostname:', :cyan)} #{vmc.guest.hostName}\t"
-        end
-
-        if get_config(:full_path)
-          actualname = ''
-          vmcp = vmc
-          while !vmcp.parent.nil? && vmcp.parent.name != 'vm'
-            actualname.concat("#{vmcp.parent.name}/")
-            vmcp = vmcp.parent
-          end
-          print "#{ui.color('Folder:', :cyan)}"
-          print "\""
-          print actualname.split('/').reverse.join('/')
-          print "\"\t"
-
-        else
-          print "#{ui.color('Folder', :cyan)}: #{vmc.parent.name}\t"
-        end
-
-        if get_config(:ip)
-          print "#{ui.color('IP:', :cyan)} #{vmc.guest.ipAddress}\t"
-        end
-        if get_config(:ips)
-          ipregex = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/
-          networks = vmc.guest.net.map { |net| "#{net.network}:" + net.ipConfig.ipAddress.select { |i| i.ipAddress[ipregex] }[0].ipAddress }
-          print "#{ui.color('IPS:', :cyan)} #{networks.join(',')}\t"
-        end
-        if get_config(:os)
-          print "#{ui.color('OS:', :cyan)} #{vmc.guest.guestFullName}\t"
-        end
-        if get_config(:ram)
-          print "#{ui.color('RAM:', :cyan)} #{vmc.summary.config.memorySizeMB}\t"
-        end
-        if get_config(:cpu)
-          print "#{ui.color('CPU:', :cyan)} #{vmc.summary.config.numCpu}\t"
-        end
-        if get_config(:alarms)
-          print "#{ui.color('Alarms:', :cyan)} #{vmc.summary.overallStatus}\t"
-        end
-        print "#{ui.color('State:', :cyan)} #{state}\t"
-        if get_config(:tools)
-          print "#{ui.color('Tools:', :cyan)} #{vmc.guest.toolsStatus}\t"
-        end
-
-        if get_config(:os_disk)
-          print "#{ui.color('OS Disks:', :cyan)}"
-          vmc.guest.disk.each do |disc|
-            print "#{disc.diskPath} #{disc.capacity / 1024 / 1024}MB Free:#{disc.freeSpace / 1024 / 1024}MB |"
-          end
-        end
-
-        if get_config(:esx_disk)
-          print "#{ui.color('ESX Disks:', :cyan)}"
-          vmc.layout.disk.each do |dsc|
-            print "#{dsc.diskFile} | "
-          end
-        end
-
-        if get_config(:snapshots)
-          unless vmc.snapshot.nil?
-            print "#{ui.color('Snapshots:', :cyan)}"
-            vmc.snapshot.rootSnapshotList.each do |snap|
-              print " #{snap.name}"
-            end
-          end
-        end
-        puts
+      if get_config(:matchname)
+        next unless vmc.name.include? config[:matchname]
       end
+
+      if get_config(:matchtools)
+        next unless vmc.guest.toolsStatus == config[:matchtools]
+      end
+
+      next if get_config(:soff) && (vmc.runtime.powerState == PS_ON)
+
+      next if get_config(:son) && (vmc.runtime.powerState == PS_OFF)
+
+      if get_config(:matchip)
+        if !vmc.guest.ipAddress.nil? && vmc.guest.ipAddress != ''
+          next unless vmc.guest.ipAddress.include? config[:matchip]
+        else
+          next
+        end
+      end
+
+      unless vmc.guest.guestFullName.nil?
+        if get_config(:matchos)
+          next unless vmc.guest.guestFullName.include? config[:matchos]
+        end
+      end
+
+      print "#{ui.color('VM Name:', :cyan)} #{vmc.name}\t"
+      if get_config(:hostname)
+        print "#{ui.color('Hostname:', :cyan)} #{vmc.guest.hostName}\t"
+      end
+
+      if get_config(:full_path)
+        actualname = ''
+        vmcp = vmc
+        while !vmcp.parent.nil? && vmcp.parent.name != 'vm'
+          actualname.concat("#{vmcp.parent.name}/")
+          vmcp = vmcp.parent
+        end
+        print "#{ui.color('Folder:', :cyan)}"
+        print "\""
+        print actualname.split('/').reverse.join('/')
+        print "\"\t"
+
+      else
+        print "#{ui.color('Folder', :cyan)}: #{vmc.parent.name}\t"
+      end
+
+      if get_config(:ip)
+        print "#{ui.color('IP:', :cyan)} #{vmc.guest.ipAddress}\t"
+      end
+      if get_config(:ips)
+        ipregex = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/
+        networks = vmc.guest.net.map { |net| "#{net.network}:" + net.ipConfig.ipAddress.select { |i| i.ipAddress[ipregex] }[0].ipAddress }
+        print "#{ui.color('IPS:', :cyan)} #{networks.join(',')}\t"
+      end
+      if get_config(:os)
+        print "#{ui.color('OS:', :cyan)} #{vmc.guest.guestFullName}\t"
+      end
+      if get_config(:ram)
+        print "#{ui.color('RAM:', :cyan)} #{vmc.summary.config.memorySizeMB}\t"
+      end
+      if get_config(:cpu)
+        print "#{ui.color('CPU:', :cyan)} #{vmc.summary.config.numCpu}\t"
+      end
+      if get_config(:alarms)
+        print "#{ui.color('Alarms:', :cyan)} #{vmc.summary.overallStatus}\t"
+      end
+      print "#{ui.color('State:', :cyan)} #{state}\t"
+      if get_config(:tools)
+        print "#{ui.color('Tools:', :cyan)} #{vmc.guest.toolsStatus}\t"
+      end
+
+      if get_config(:os_disk)
+        print "#{ui.color('OS Disks:', :cyan)}"
+        vmc.guest.disk.each do |disc|
+          print "#{disc.diskPath} #{disc.capacity / 1024 / 1024}MB Free:#{disc.freeSpace / 1024 / 1024}MB |"
+        end
+      end
+
+      if get_config(:esx_disk)
+        print ui.color('ESX Disks:', :cyan)
+        vmc.layout.disk.each do |dsc|
+          print "#{dsc.diskFile} | "
+        end
+      end
+
+      if get_config(:snapshots)
+        unless vmc.snapshot.nil?
+          print ui.color('Snapshots:', :cyan)
+          vmc.snapshot.rootSnapshotList.each do |snap|
+            print " #{snap.name}"
+          end
+        end
+      end
+      puts
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,59 +41,57 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # These two settings work together to allow you to limit a spec run
-  # to individual examples or groups you care about by tagging them with
-  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
-  # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#new__config_option_to_disable_rspeccore_monkey_patching
-  config.disable_monkey_patching!
-
-  # This setting enables warnings. It's recommended, but in some cases may
-  # be too noisy due to issues in dependencies.
-  config.warnings = true
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = 'doc'
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # These two settings work together to allow you to limit a spec run
+  #   # to individual examples or groups you care about by tagging them with
+  #   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
+  #   # get run.
+  #   config.filter_run :focus
+  #   config.run_all_when_everything_filtered = true
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#new__config_option_to_disable_rspeccore_monkey_patching
+  #   config.disable_monkey_patching!
+  #
+  #   # This setting enables warnings. It's recommended, but in some cases may
+  #   # be too noisy due to issues in dependencies.
+  #   config.warnings = true
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = 'doc'
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end
 
 RSpec.shared_context 'basic_setup' do
@@ -101,7 +99,7 @@ RSpec.shared_context 'basic_setup' do
   let(:empty_folder) { double('Folder', childEntity: [], children: []) }
   let(:guest_id) { 'Other Linux' }
   let(:host) { double('Host', resourcePool: double('ResourcePool')) }
-  let(:template) { double('Template', config: double(guestId: guest_id )) }
+  let(:template) { double('Template', config: double(guestId: guest_id)) }
   let(:vim) { double('VimConnection', serviceContent: service_content) }
 
   before do
@@ -109,12 +107,12 @@ RSpec.shared_context 'basic_setup' do
     # It is difficult to mock this because the current implementation checks
     # for explicity RbVmomi class names
     allow(subject).to receive(:datacenter).and_return(datacenter)
-    allow(subject).to receive(:find_available_hosts).and_return( [host])
+    allow(subject).to receive(:find_available_hosts).and_return([host])
 
     allow(subject).to receive(:find_in_folder).and_return(template)
     allow(service_content).to receive(:virtualDiskManager) # what does this call actually do?
 
-    subject.name_args = [ 'foo' ]
+    subject.name_args = ['foo']
     subject.config[:source_vm] = 'my_template'
     subject.config[:folder] = ''
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,8 +99,9 @@ end
 RSpec.shared_context 'basic_setup' do
   let(:datacenter) { double('Datacenter', vmFolder: empty_folder, hostFolder: empty_folder) }
   let(:empty_folder) { double('Folder', childEntity: [], children: []) }
+  let(:guest_id) { 'Other Linux' }
   let(:host) { double('Host', resourcePool: double('ResourcePool')) }
-  let(:template) { double('Template', config: {}) }
+  let(:template) { double('Template', config: double(guestId: guest_id )) }
   let(:vim) { double('VimConnection', serviceContent: service_content) }
 
   before do
@@ -113,7 +114,7 @@ RSpec.shared_context 'basic_setup' do
     allow(subject).to receive(:find_in_folder).and_return(template)
     allow(service_content).to receive(:virtualDiskManager) # what does this call actually do?
 
-    subject.name_args = 'foo'
+    subject.name_args = [ 'foo' ]
     subject.config[:source_vm] = 'my_template'
     subject.config[:folder] = ''
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,3 +95,26 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
 end
+
+RSpec.shared_context 'basic_setup' do
+  let(:datacenter) { double('Datacenter', vmFolder: empty_folder, hostFolder: empty_folder) }
+  let(:empty_folder) { double('Folder', childEntity: [], children: []) }
+  let(:host) { double('Host', resourcePool: double('ResourcePool')) }
+  let(:template) { double('Template', config: {}) }
+  let(:vim) { double('VimConnection', serviceContent: service_content) }
+
+  before do
+    allow(subject).to receive(:vim_connection).and_return(vim)
+    # It is difficult to mock this because the current implementation checks
+    # for explicity RbVmomi class names
+    allow(subject).to receive(:datacenter).and_return(datacenter)
+    allow(subject).to receive(:find_available_hosts).and_return( [host])
+
+    allow(subject).to receive(:find_in_folder).and_return(template)
+    allow(service_content).to receive(:virtualDiskManager) # what does this call actually do?
+
+    subject.name_args = 'foo'
+    subject.config[:source_vm] = 'my_template'
+    subject.config[:folder] = ''
+  end
+end

--- a/spec/vsphere_vm_clone_spec.rb
+++ b/spec/vsphere_vm_clone_spec.rb
@@ -53,7 +53,7 @@ describe Chef::Knife::VsphereVmClone do
 
     context 'the mac is given' do
       it 'requires an ip' do
-        subject.name_args = [ 'foo' ]
+        subject.name_args = ['foo']
         subject.config[:customization_macs] = '00:11:22:33:44:55'
 
         expect { subject.run }.to raise_error SystemExit
@@ -62,7 +62,7 @@ describe Chef::Knife::VsphereVmClone do
 
     context 'the mac is not given' do
       before do
-        subject.name_args = [ 'foo' ]
+        subject.name_args = ['foo']
 
         allow(subject).to receive(:find_in_folder).and_return(template)
       end
@@ -86,7 +86,7 @@ describe Chef::Knife::VsphereVmClone do
 
     context 'naming the vm in the identity' do
       context 'no name is passed' do
-        it "should use the vmname in the identity" do
+        it 'should use the vmname in the identity' do
           expect(template).to receive(:CloneVM_Task) do |args|
             expect(args[:spec].customization.identity.hostName.name).to eq 'foo'
           end.and_return(task)
@@ -100,7 +100,7 @@ describe Chef::Knife::VsphereVmClone do
           subject.config[:customization_hostname] = 'bar'
         end
 
-        it "should use the passed name in the identity" do
+        it 'should use the passed name in the identity' do
           expect(template).to receive(:CloneVM_Task) do |args|
             expect(args[:spec].customization.identity.hostName.name).to eq 'bar'
           end.and_return(task)
@@ -108,7 +108,7 @@ describe Chef::Knife::VsphereVmClone do
           subject.run
         end
 
-        it "has a blank domain name" do
+        it 'has a blank domain name' do
           expect(template).to receive(:CloneVM_Task) do |args|
             expect(args[:spec].customization.identity.domain).to eq ''
           end.and_return(task)
@@ -122,7 +122,7 @@ describe Chef::Knife::VsphereVmClone do
           subject.config[:customization_domain] = 'example.com'
         end
 
-        it "should use the vmname" do
+        it 'should use the vmname' do
           expect(template).to receive(:CloneVM_Task) do |args|
             expect(args[:spec].customization.identity.hostName.name).to eq 'foo'
           end.and_return(task)
@@ -130,7 +130,7 @@ describe Chef::Knife::VsphereVmClone do
           subject.run
         end
 
-        it "adds the domain name to the spec" do
+        it 'adds the domain name to the spec' do
           expect(template).to receive(:CloneVM_Task) do |args|
             expect(args[:spec].customization.identity.domain).to eq 'example.com'
           end.and_return(task)

--- a/spec/vsphere_vm_clone_spec.rb
+++ b/spec/vsphere_vm_clone_spec.rb
@@ -2,9 +2,13 @@ require 'spec_helper'
 require 'chef/knife/vsphere_vm_clone'
 
 describe Chef::Knife::VsphereVmClone do
-  let(:datacenter) { double('Datacenter') }
+  let(:datacenter) { double('Datacenter', vmFolder: empty_folder, hostFolder: empty_folder) }
   let(:vim) { double('VimConnection', serviceContent: service_content) }
   let(:service_content) { double('ServiceContent') }
+  let(:root_folder) { double('RootFolder', children: []) }
+  let(:empty_folder) { double('Folder', childEntity: [], children: []) }
+  let(:host) { double('Host', resourcePool: double('ResourcePool')) }
+  let(:task) { double('Task', wait_for_completion: 'done') }
 
   subject { described_class.new }
 
@@ -12,9 +16,16 @@ describe Chef::Knife::VsphereVmClone do
     subject.config[:random_vmname_prefix] = 'vm-'
     subject.config[:vsphere_pass] = 'password'
     subject.config[:vsphere_host] = 'host'
+    subject.config[:verbosity] = 0
+    subject.config[:customization_ips] = Chef::Knife::VsphereVmClone::NO_IPS
+    subject.config[:customization_macs] = Chef::Knife::VsphereVmClone::AUTO_MAC
   end
 
   context 'input handling' do
+    before do
+      subject.config[:source_vm] = 'my_template'
+    end
+
     it 'requires a vm name' do
       expect { subject.run }.to raise_error SystemExit
     end
@@ -24,5 +35,58 @@ describe Chef::Knife::VsphereVmClone do
       expect(subject).to receive(:vim_connection).and_raise ArgumentError
       expect { subject.run }.to raise_error ArgumentError
     end
+  end
+
+  context 'customizing the mac' do
+    let(:template) { double('Template', config: {}) }
+
+    before do
+      allow(subject).to receive(:vim_connection).and_return(vim)
+      # It is difficult to mock this because the current implementation checks
+      # for explicity RbVmomi class names
+      allow(subject).to receive(:datacenter).and_return(datacenter)
+      allow(subject).to receive(:find_available_hosts).and_return( [host])
+
+      allow(service_content).to receive(:virtualDiskManager) # what does this call actually do?
+      subject.config[:folder] = ''
+      subject.config[:source_vm] = 'my_template'
+    end
+
+    context 'the mac is given' do
+      it 'requires an ip' do
+        subject.name_args = 'foo'
+        subject.config[:customization_macs] = '00:11:22:33:44:55'
+
+        expect { subject.run }.to raise_error SystemExit
+      end
+    end
+
+    context 'the mac is not given' do
+      before do
+        subject.name_args = 'foo'
+
+        allow(subject).to receive(:find_in_folder).and_return(template)
+      end
+
+      it 'runs without specifying an ip' do
+        expect(template).to receive(:CloneVM_Task).and_return(task)
+        expect { subject.run }.to_not raise_error
+      end
+
+      it 'runs while specifying an ip' do
+        subject.config[:customization_ips] = '1.2.3.4'
+
+        expect(template).to receive(:CloneVM_Task).and_return(task)
+        expect { subject.run }.to_not raise_error
+      end
+    end
+  end
+
+  context 'customizations' do
+    context 'skip customizations'
+    context 'determining the hostname'
+    context 'windows clone'
+    context 'linux clone'
+    context 'neither windows or linux'
   end
 end

--- a/spec/vsphere_vm_clone_spec.rb
+++ b/spec/vsphere_vm_clone_spec.rb
@@ -39,13 +39,12 @@ describe Chef::Knife::VsphereVmClone do
   end
 
   context 'customizing the mac' do
-
     before do
       allow(subject).to receive(:vim_connection).and_return(vim)
       # It is difficult to mock this because the current implementation checks
       # for explicity RbVmomi class names
       allow(subject).to receive(:datacenter).and_return(datacenter)
-      allow(subject).to receive(:find_available_hosts).and_return( [host])
+      allow(subject).to receive(:find_available_hosts).and_return([host])
 
       allow(service_content).to receive(:virtualDiskManager) # what does this call actually do?
       subject.config[:folder] = ''

--- a/spec/vsphere_vm_vmdk_add_spec.rb
+++ b/spec/vsphere_vm_vmdk_add_spec.rb
@@ -41,6 +41,5 @@ describe Chef::Knife::VsphereVmVmdkAdd do
 
       expect { subject.run }.to raise_error SystemExit
     end
-
   end
 end


### PR DESCRIPTION
    Fix bug with no cmacs or cips; tests; refactor

    I was sent a bug privately where cloning a VM with no --cmacs or --cips
    triggered an abort. When I updated --cmacs to default to `auto` I didn't
    change that guard clause, so the code always assumed there was a cmac
    specified. So let's get away from checking strings ;)

    Also took this opportunity to dive into the mocking necessary to test a
    clone. There's a lot of mocking the SUT but much of it is unavoidable. I
    moved some of the code around so that the mocks were working on smaller
    pieces of code, and I hope that I'll be able to test those pieces of
    code more thoroughly.

    These tests in the cloning code do set us up to be able to test the
    clone specs being sent with vmware.