### PR TITLE
Fix #279: VM clone with resource pool and linked clone

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -495,7 +495,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     end
 
     if get_config(:linked_clone)
-      rspec = RbVmomi::VIM.VirtualMachineRelocateSpec(diskMoveType: :moveChildMostDiskBacking)
+      rspec.diskMoveType = :moveChildMostDiskBacking
     end
 
     if get_config(:datastore) && get_config(:datastorecluster)


### PR DESCRIPTION
The bug was caused by overwriting rspec, not updating its properties.
Fixed by just setting diskMoveType in the existing rspec, which
contains a resource pool.

Not sure if I should bump the version?
