### PR TITLE
Allow us to pass a url to the (windows) chef install

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ to bootstrap the VM, but at the very least `--bootstrap` is required to do so.
 ```bash
 --bootstrap - Bootstrap the VM after cloning. Implies --start
 --bootstrap-ipv4 - Force using an IPv4 address when a NIC has both IPv4 and IPv6 addresses.
+--bootstrap-msi-url URL - Location of the Chef Client MSI if not default from chef.io
 --bootstrap-nic INTEGER - Network interface to use when multiple NICs are defined on a template.
 --bootstrap-proxy PROXY_URL - The proxy server for the node being bootstrapped
 --bootstrap-vault-file VAULT_FILE - A JSON file with a list of vault(s) and item(s) to be updated

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -146,6 +146,10 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
          long: '--fqdn SERVER_FQDN',
          description: 'Fully qualified hostname for bootstrapping'
 
+  option :bootstrap_msi_url,
+         long: '--bootstrap-msi-url URL',
+         description: 'Location of the Chef Client MSI. The default templates will prefer to download from this location.'
+
   option :bootstrap_protocol,
          long: '--bootstrap-protocol protocol',
          description: 'Protocol to bootstrap windows servers. options: winrm/ssh',
@@ -786,6 +790,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
       ui.error('Unsupported Bootstrapping Protocol. Supports : winrm, ssh')
       exit 1
     end
+    bootstrap.config[:msi_url] = get_config(:bootstrap_msi_url)
     bootstrap_common_params(bootstrap)
   end
 


### PR DESCRIPTION
Helpful for people that can't access the Internet from their Windows boxen, or otherwise have a customized/pinned MSI they want to use.

Fixes #289
Fixes #272