### PR TITLE
Add --node-ssl-verify-mode option for bootstrapping in VM clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ to bootstrap the VM, but at the very least `--bootstrap` is required to do so.
 --json-attributes - A JSON string to be added to the first run of chef-client
 --node-name NAME - The Chef node name for your new node
 --no-host-key-verify - Disable host key verification
+--node-ssl-verify-mode [peer|none] - Whether or not to verify the SSL cert for all HTTPS requests
 --prerelease - Install the pre-release chef gems
 --run-list RUN_LIST - Comma separated list of roles/recipes to apply
 --secret-file SECRET_FILE - A file containing the secret key to use to encrypt data bag item values

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -257,6 +257,11 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
          description: 'Disable host key verification',
          boolean: true
 
+  option :node_ssl_verify_mode,
+         long: '--node-ssl-verify-mode [peer|none]',
+         description: 'Whether or not to verify the SSL cert for all HTTPS requests when bootstrapping',
+         boolean: true
+
   option :first_boot_attributes,
          short: '-j JSON_ATTRIBS',
          long: '--json-attributes',
@@ -769,6 +774,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     bootstrap.config[:bootstrap_vault_item] = get_config(:bootstrap_vault_item)
     # may be needed for vpc mode
     bootstrap.config[:no_host_key_verify] = get_config(:no_host_key_verify)
+    bootstrap.config[:node_ssl_verify_mode] = get_config(:node_ssl_verify_mode)
     bootstrap
   end
 

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -259,8 +259,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
 
   option :node_ssl_verify_mode,
          long: '--node-ssl-verify-mode [peer|none]',
-         description: 'Whether or not to verify the SSL cert for all HTTPS requests when bootstrapping',
-         boolean: true
+         description: 'Whether or not to verify the SSL cert for all HTTPS requests when bootstrapping'
 
   option :first_boot_attributes,
          short: '-j JSON_ATTRIBS',


### PR DESCRIPTION
Added an option that is passed on to knife bootstrap so that a
node can talk to the Chef server without getting a certificate
error.

It is used as: --node-ssl-verify-mode none

The intention is that it eases VM template setup when using
an internal, trusted Chef server.
