### PR TITLE
Provide a sane error message for Windows failures

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -629,7 +629,9 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
       hostname = config[:customization_hostname] || config[:vmname]
 
       if windows?(src_config)
-        # TODO: This is just copying itself onto itself, isn't it?
+        # We should get here with the customizations set, either by a plugin or a --cspec
+        fatal_exit 'Windows clones need a customization identity. Try passing a --cspec or making a --cplugin' if cust_spec.identity.props.empty?
+
         identification = RbVmomi::VIM.CustomizationIdentification(
           joinWorkgroup: cust_spec.identity.identification.joinWorkgroup
         )

--- a/spec/vsphere_vm_clone_spec.rb
+++ b/spec/vsphere_vm_clone_spec.rb
@@ -183,10 +183,14 @@ describe Chef::Knife::VsphereVmClone do
     end
 
     context 'windows clone' do
-      before do
-        let(:guest_id) { 'Windows 3.1' }
+      let(:guest_id) { 'Windows 3.1' }
+
+      it 'provides an error message when called with no customization' do
+        expect(subject).to receive(:fatal_exit).and_raise ArgumentError
+        expect { subject.run }.to raise_error ArgumentError
       end
     end
+
     context 'linux clone'
     context 'neither windows or linux' do
       before do


### PR DESCRIPTION
This is the most common question we get -- someone tries to clone a
Windows box without enough customizations. It requires either a cspec or
a plugin as there are far too many command line options to make sense
(maybe someday we allow them to pass the identity as JSON since this is
so common)

Fixes #298 and #223