### PR TITLE
Support tagging in bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ to bootstrap the VM, but at the very least `--bootstrap` is required to do so.
 --ssh-port PORT - SSH port
 --ssh-user USERNAME - SSH username
 --sysprep_timeout TIMEOUT - Wait TIMEOUT seconds for sysprep event before continuing with bootstrap
+--tags TAG1,TAG2 - Tag the node with the given list of tags
 ```
 
 ### Customization options

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -227,7 +227,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
   option :tags,
          long: '--tags TAGS',
          description: 'Comma separated list of tags to apply to the node',
-         proc: lambda { |o| o.split(/[\s,]+/) },
+         proc: ->(tags) { tags.split(/[\s,]+/) },
          default: []
 
   option :template_file,

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -224,6 +224,12 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
          proc: proc { |d| Chef::Config[:knife][:distro] = d },
          default: 'chef-full'
 
+  option :tags,
+         long: '--tags TAGS',
+         description: 'Comma separated list of tags to apply to the node',
+         proc: lambda { |o| o.split(/[\s,]+/) },
+         default: []
+
   option :template_file,
          long: '--template-file TEMPLATE',
          description: 'Full path to location of template to use'
@@ -776,6 +782,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     # may be needed for vpc mode
     bootstrap.config[:no_host_key_verify] = get_config(:no_host_key_verify)
     bootstrap.config[:node_ssl_verify_mode] = get_config(:node_ssl_verify_mode)
+    bootstrap.config[:tags] = get_config(:tags)
     bootstrap
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,5 +123,6 @@ RSpec.shared_context 'basic_setup' do
     subject.config[:run_list] = []
     subject.config[:ssh_port] = 22
     subject.config[:ssh_user] = 'root'
+    subject.config[:tags] = []
   end
 end

--- a/spec/vsphere_vm_clone_spec.rb
+++ b/spec/vsphere_vm_clone_spec.rb
@@ -221,8 +221,6 @@ describe Chef::Knife::VsphereVmClone do
       end
 
       it 'calls Chef to bootstrap' do
-        subject.config['run_list'] = %w{role[a] recipe[foo::bar]}
-
         expect(chef).to receive(:run) do
           expect(chef.name_args).to eq(['foo.bar'])
         end
@@ -233,11 +231,41 @@ describe Chef::Knife::VsphereVmClone do
       it 'sends the runlist' do
         subject.config[:run_list] = %w{role[a] recipe[foo::bar]}
         expect(chef).to receive(:run) do
-          expect(chef.name_args).to eq(['foo.bar'])
           expect(chef.config[:run_list]).to eq(%w{role[a] recipe[foo::bar]})
         end
 
         subject.run
+      end
+    end
+
+    context 'handing over tags' do
+      before do
+        # Avoid the complexity inside `guest_address`
+        subject.config[:fqdn] = 'foo.bar'
+      end
+
+      context 'without tags' do
+        it 'does not set any tags' do
+          expect(chef).to receive(:run) do
+            expect(chef.config[:tags]).to eq([])
+          end
+
+          subject.run
+        end
+      end
+
+      context 'with tags' do
+        before do
+          subject.config[:tags] = %w(tag1 tag2)
+        end
+
+        it 'sends the tags to the bootstrap' do
+          expect(chef).to receive(:run) do
+            expect(chef.config[:tags]).to eq(%w(tag1 tag2))
+          end
+
+          subject.run
+        end
       end
     end
   end


### PR DESCRIPTION
Chef bootstrap supports a `--tags` option to tag the node after
bootstrap, and this lets us use it after cloning.

Note that we used to be able to do this by passing the tags in the
attributes, e.g.

```
 --json-attributes='{ "tags": ["mytag"] }'
```

but who has time for that!?

Fixes #297