### PR TITLE
Update vsphere_vm_disk_list.rb

### DIFF
--- a/lib/chef/knife/vsphere_vm_disk_list.rb
+++ b/lib/chef/knife/vsphere_vm_disk_list.rb
@@ -26,7 +26,7 @@ class Chef::Knife::VsphereVmDiskList < Chef::Knife::BaseVsphereCommand
     disks.each do |disk|
       puts '%3d %20s %s' % [disk.unitNumber,
                             disk.deviceInfo.label,
-                            Filesize.from("#{disk.capacityInKB} KB").pretty]
+                            Filesize.from("#{disk.capacityInKB} KiB").pretty]
     end
   end
 end


### PR DESCRIPTION
VSPHERE API "disk.capacityInKB" returns capacity in KiB, not in KB.

Bad result : 
  0          Hard disk 1 20.97 GB
  1          Hard disk 2 260.05 GB
  2          Hard disk 3 2.10 GB
  3          Hard disk 4 1.05 GB

Correct :
  0          Hard disk 1 20.00 GiB
  1          Hard disk 2 248.00 GiB
  2          Hard disk 3 2.00 GiB
  3          Hard disk 4 1.00 GiB