### PR TITLE
check if config[:customization_ips] is still the default NO_IPS

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -621,7 +621,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
       cust_spec.globalIPSettings.dnsSuffixList = get_config(:customization_dns_suffixes).split(',')
     end
 
-    if config[:customization_ips]
+    if config[:customization_ips] != NO_IPS
       cust_spec.nicSettingMap = config[:customization_ips].split(',').map.with_index { |cust_ip, index|
         generate_adapter_map(cust_ip, get_config(:customization_gw), mac_list[index])
       }


### PR DESCRIPTION
otherwise nicSettingMap is empty and will lead to
`ERROR: RbVmomi::Fault: NicSettingMismatch: fault.NicSettingMismatch.summary`

in working 1.2.13 the VirtualMachineCloneSpec was:
```
VirtualMachineCloneSpec(
  config: ...,
  customization: ...,
    identity: ...,
    nicSettingMap: [CustomizationAdapterMapping(
       adapter: CustomizationIPSettings(
         dnsServerList: [],
         dynamicProperty: [],
         gateway: [],
         ip: CustomizationDhcpIpGenerator( dynamicProperty: [] )
       ),
       dynamicProperty: []
     )],
    options: ...
  ),
  location: ...,
  powerOn: ...,
  template: ...
)
```
till 1.2.21 it was:
```
VirtualMachineCloneSpec(
  config: ...,
  customization: ...,
    identity: ...,
    nicSettingMap: [],
    options: ...
  ),
  location: ...,
  powerOn: ...,
  template: ...
)
