### PR TITLE
Clone to host

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -1,3 +1,4 @@
+require 'byebug'
 #
 # Author:: Ezra Pagel (<ezra@cpan.org>)
 # Contributor:: Jesse Campbell (<hikeit@gmail.com>)
@@ -43,6 +44,10 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
   option :datastorecluster,
          long: '--datastorecluster STORE',
          description: 'The datastorecluster into which to put the cloned VM'
+
+  option :host,
+         long: '--host HOST',
+         description: 'The host into which to put the cloned VM'
 
   option :resource_pool,
          long: '--resource-pool POOL',
@@ -505,16 +510,38 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     hosts
   end
 
+  def all_the_hosts
+    hosts = traverse_folders_for_computeresources(datacenter.hostFolder)
+    all_hosts = []
+    hosts.each do |host|
+      if host.is_a? RbVmomi::VIM::ClusterComputeResource
+        all_hosts.concat(host.host)
+      else
+        all_hosts.push host
+      end
+    end
+    all_hosts
+  end
+
+  def find_host(host_name)
+    host = all_the_hosts.find { |host| host.name == host_name }
+    raise "Can't find #{host_name}. I found #{all_the_hosts.map(&:name)}" unless host
+    host
+  end
+
   # Builds a CloneSpec
   def generate_clone_spec(src_config)
     rspec = RbVmomi::VIM.VirtualMachineRelocateSpec
 
-    rspec.pool = if get_config(:resource_pool)
-                   find_pool(get_config(:resource_pool))
-                 else
-                   hosts = find_available_hosts
-                   hosts.first.resourcePool
-                 end
+    case
+    when get_config(:host)
+      rspec.host = find_host(get_config(:host))
+    when get_config(:resource_pool)
+      rspec.pool = find_pool(get_config(:resource_pool))
+    else
+      hosts = find_available_hosts
+      hosts.first.resourcePool
+    end
 
     rspec.diskMoveType = :moveChildMostDiskBacking if get_config(:linked_clone)
 

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -536,11 +536,13 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     case
     when get_config(:host)
       rspec.host = find_host(get_config(:host))
+      hosts = find_available_hosts
+      rspec.pool = hosts.first.resourcePool
     when get_config(:resource_pool)
       rspec.pool = find_pool(get_config(:resource_pool))
     else
       hosts = find_available_hosts
-      hosts.first.resourcePool
+      rspec.pool = hosts.first.resourcePool
     end
 
     rspec.diskMoveType = :moveChildMostDiskBacking if get_config(:linked_clone)

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -1,5 +1,3 @@
-require 'byebug'
-#
 # Author:: Ezra Pagel (<ezra@cpan.org>)
 # Contributor:: Jesse Campbell (<hikeit@gmail.com>)
 # Contributor:: Bethany Erskine (<bethany@paperlesspost.com>)
@@ -650,7 +648,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
       cust_spec.globalIPSettings.dnsSuffixList = get_config(:customization_dns_suffixes).split(',')
     end
 
-    if config[:customization_ips] != NO_IPS
+    if config[:customization_ips]
       cust_spec.nicSettingMap = config[:customization_ips].split(',').map.with_index { |cust_ip, index|
         generate_adapter_map(cust_ip, get_config(:customization_gw), mac_list[index])
       }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -114,7 +114,8 @@ RSpec.shared_context 'basic_setup' do
   let(:datacenter) { double('Datacenter', vmFolder: empty_folder, hostFolder: empty_folder) }
   let(:empty_folder) { double('Folder', childEntity: [], children: []) }
   let(:guest_id) { 'Other Linux' }
-  let(:host) { double('Host', resourcePool: double('ResourcePool')) }
+  let(:pool) { double('ResourcePool') }
+  let(:host) { double('Host', resourcePool: pool) }
   let(:service_content) { double('ServiceContent') }
   let(:template) { double('Template', config: double(guestId: guest_id)) }
   let(:vim) { double('VimConnection', serviceContent: service_content) }

--- a/spec/vsphere_vm_clone_spec.rb
+++ b/spec/vsphere_vm_clone_spec.rb
@@ -39,6 +39,31 @@ describe Chef::Knife::VsphereVmClone do
     end
   end
 
+  context 'cloning to a specific host' do
+    include_context 'basic_setup'
+
+    let(:desired_host) { 'myhost' }
+
+    before do
+      subject.config[:host] = desired_host
+      expect(subject).to receive(:find_host).with(desired_host).and_return(host)
+    end
+
+    it 'creates a specification that clones to the given host' do
+      expect(template).to receive(:CloneVM_Task) do |args|
+        expect(args[:spec].location.host).to eq host
+      end.and_return(task)
+      subject.run
+    end
+
+    it 'requires a pool' do
+      expect(template).to receive(:CloneVM_Task) do |args|
+        expect(args[:spec].location.pool).to eq pool
+      end.and_return(task)
+      subject.run
+    end
+  end
+
   context 'customizing the mac' do
     before do
       allow(subject).to receive(:vim_connection).and_return(vim)


### PR DESCRIPTION
Fill out the relocation spec with a host so people can deploy to a specific host using `--host`.

Note that we're [required to select a pool](https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.RelocateSpec.html) in addition to the host because we're cloning. So we rely on the default pool picking logic.