### PR TITLE
add support for filtering networks by dvswitch

### DIFF
--- a/lib/chef/knife/base_vsphere_command.rb
+++ b/lib/chef/knife/base_vsphere_command.rb
@@ -223,10 +223,22 @@ class Chef
         base_entity
       end
 
-      def find_network(networkName)
+      def find_network(networkName, dvswitch = nil)
+        switch_uuid = true if dvswitch =~ /^([0-9a-f]{2}[ -]{0,1})*$/
+
         dc = datacenter
         base_entity = dc.network
-        base_entity.find { |f| f.name == networkName } || abort("no such network #{networkName}")
+
+        networks =
+          base_entity.select { |f| f.name == networkName } ||
+          abort("no such network #{networkName}")
+
+        if dvswitch
+          return networks.find { |f| f.config.distributedVirtualSwitch.uuid == dvswitch } if switch_uuid
+          return networks.find { |f| f.config.distributedVirtualSwitch.name == dvswitch }
+        end
+
+        networks.first
       end
 
       def find_pool(poolName)

--- a/lib/chef/knife/base_vsphere_command.rb
+++ b/lib/chef/knife/base_vsphere_command.rb
@@ -227,9 +227,8 @@ class Chef
         dc = datacenter
         base_entity = dc.network
 
-        networks =
-          base_entity.select { |f| f.name == networkName } ||
-          abort("no such network #{networkName}")
+        networks = base_entity.select { |f| f.name == networkName }
+        abort("no such network #{networkName}") if networks.empty?
 
         if dvswitch && dvswitch != 'auto'
           return networks.find do |f|

--- a/lib/chef/knife/base_vsphere_command.rb
+++ b/lib/chef/knife/base_vsphere_command.rb
@@ -12,7 +12,6 @@ require 'filesize'
 PS_ON ||= 'poweredOn'.freeze
 PS_OFF ||= 'poweredOff'.freeze
 PS_SUSPENDED ||= 'suspended'.freeze
-UUID_RE = /^([0-9a-f]{2}[ -]{0,1})*$/
 
 # Base class for vsphere knife commands
 class Chef

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -597,7 +597,13 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
 
     if get_config(:customization_vlan)
       vlan_list = get_config(:customization_vlan).split(',')
-      networks = vlan_list.map { |vlan| find_network(vlan) }
+      networks =
+        if get_config(:customization_sw_uuid)
+          sw_uuid = get_config(:customization_sw_uuid)
+          vlan_list.map { |vlan| find_network(vlan, sw_uuid) }
+        else
+          vlan_list.map { |vlan| find_network(vlan) }
+        end
 
       cards = src_config.hardware.device.grep(RbVmomi::VIM::VirtualEthernetCard)
 

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -597,13 +597,8 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
 
     if get_config(:customization_vlan)
       vlan_list = get_config(:customization_vlan).split(',')
-      networks =
-        if get_config(:customization_sw_uuid)
-          sw_uuid = get_config(:customization_sw_uuid)
-          vlan_list.map { |vlan| find_network(vlan, sw_uuid) }
-        else
-          vlan_list.map { |vlan| find_network(vlan) }
-        end
+      sw_uuid   = get_config(:customization_sw_uuid)
+      networks  = vlan_list.map { |vlan| find_network(vlan, sw_uuid) }
 
       cards = src_config.hardware.device.grep(RbVmomi::VIM::VirtualEthernetCard)
 


### PR DESCRIPTION
This resolves #307 for my purposes, and shouldn't affect the operation of any other reference to the method... It also lays the groundwork for passing the DVSwitch name instead of UUID, which is a feature request I've gotten from internal customers.