### PR TITLE
add proper exit codes

### DIFF
--- a/lib/chef/knife/vsphere_datastore_list.rb
+++ b/lib/chef/knife/vsphere_datastore_list.rb
@@ -44,7 +44,6 @@ class Chef::Knife::VsphereDatastoreList < Chef::Knife::BaseVsphereCommand
     pools = find_pools_and_clusters(folder, target_pool)
     if target_pool && pools.empty?
       fatal_exit("Pool #{target_pool} not found")
-      return
     end
 
     pool_info = pools.map do |pool|

--- a/lib/chef/knife/vsphere_datastore_list.rb
+++ b/lib/chef/knife/vsphere_datastore_list.rb
@@ -43,7 +43,7 @@ class Chef::Knife::VsphereDatastoreList < Chef::Knife::BaseVsphereCommand
 
     pools = find_pools_and_clusters(folder, target_pool)
     if target_pool && pools.empty?
-      puts "Pool #{target_pool} not found"
+      fatal_exit("Pool #{target_pool} not found")
       return
     end
 

--- a/lib/chef/knife/vsphere_hosts_list.rb
+++ b/lib/chef/knife/vsphere_hosts_list.rb
@@ -22,7 +22,7 @@ class Chef::Knife::VsphereHostsList < Chef::Knife::BaseVsphereCommand
 
     pools = find_pools_and_clusters(folder, target_pool)
     if target_pool && pools.empty?
-      puts "Pool #{target_pool} not found"
+      fatal_exit("Pool #{target_pool} not found")
       return
     end
 

--- a/lib/chef/knife/vsphere_hosts_list.rb
+++ b/lib/chef/knife/vsphere_hosts_list.rb
@@ -23,7 +23,6 @@ class Chef::Knife::VsphereHostsList < Chef::Knife::BaseVsphereCommand
     pools = find_pools_and_clusters(folder, target_pool)
     if target_pool && pools.empty?
       fatal_exit("Pool #{target_pool} not found")
-      return
     end
 
     pool_list = pools.map do |pool|


### PR DESCRIPTION
host and datastore list commands are missing proper exit codes when failing to find the pool.