### PR TITLE
add formatted output and ability to filter on pool/cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,8 @@ Gets the datastore with the most free space
 
 ```bash
 --regex           - Pattern to match the datastore name
+--vlan            - Require listed vlan available to datastore's parent
+--pool            - Pool or Cluster to search for datastores in
 ```
 
 ## `knife vsphere datastore file`

--- a/lib/chef/knife/vsphere_datastore_maxfree.rb
+++ b/lib/chef/knife/vsphere_datastore_maxfree.rb
@@ -34,7 +34,7 @@ class Chef::Knife::VsphereDatastoreMaxfree < Chef::Knife::BaseVsphereCommand
 
   option :pool,
          long: '--pool pool',
-         description: 'Target pool'
+         description: 'Pool or Cluster to search for datastores in'
 
   common_options
 


### PR DESCRIPTION
- leverage `datacenter` function from base
- add option for filtering datastores by cluster/pool
- add formatted output