### PR TITLE
For Windows cloning, the license is optional

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -690,7 +690,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
         )
         license_file_print_data = RbVmomi::VIM.CustomizationLicenseFilePrintData(
           autoMode: cust_spec.identity.licenseFilePrintData.autoMode
-        )
+        ) if cust_spec.identity.licenseFilePrintData # optional param
 
         user_data = RbVmomi::VIM.CustomizationUserData(
           fullName: cust_spec.identity.userData.fullName,


### PR DESCRIPTION
It was pointed out in #181 that the license data is optional, and also
in the
[docs](https://pubs.vmware.com/vi3/sdk/ReferenceGuide/vim.vm.customization.Sysprep.html#field_detail).

Add some unit tests around cloning a Windows VM to test this, and only
set the license if it's in the cspec.