### PR TITLE
Fix issue where --cdomain is ignored on Windows clones

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -687,22 +687,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
         # We should get here with the customizations set, either by a plugin or a --cspec
         fatal_exit 'Windows clones need a customization identity. Try passing a --cspec or making a --cplugin' if cust_spec.identity.props.empty?
 
-        # If --cdomain matches what is in --cspec then use identification from the --cspec, else use --cdomain
-        domain = get_config(:customization_domain)
-        if domain
-          if domain == cust_spec.identity.identification.joinDomain
-            identification = cust_spec.identity.identification
-          else
-            identification = RbVmomi::VIM.CustomizationIdentification(
-              joinDomain: domain
-            )
-          end
-        else
-          # Fall back to original behavior of using joinWorkgroup from the --cspec
-          identification = RbVmomi::VIM.CustomizationIdentification(
-            joinWorkgroup: cust_spec.identity.identification.joinWorkgroup
-          )
-        end
+        identification = identification_for_spec(cust_spec)
 
         license_file_print_data = RbVmomi::VIM.CustomizationLicenseFilePrintData(
           autoMode: cust_spec.identity.licenseFilePrintData.autoMode
@@ -996,5 +981,22 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
 
   def bootstrap_nic_index
     Integer(get_config(:bootstrap_nic))
+  end
+
+  def identification_for_spec(cust_spec)
+    # If --cdomain matches what is in --cspec then use identification from the --cspec, else use --cdomain
+    case domain = get_config(:customization_domain)
+    when nil?
+      # Fall back to original behavior of using joinWorkgroup from the --cspec
+      RbVmomi::VIM.CustomizationIdentification(
+        joinWorkgroup: cust_spec.identity.identification.joinWorkgroup
+      )
+    when cust_spec.identity.identification.joinDomain
+      cust_spec.identity.identification
+    else
+      RbVmomi::VIM.CustomizationIdentification(
+        joinDomain: domain
+      )
+    end
   end
 end

--- a/spec/vsphere_vm_clone_spec.rb
+++ b/spec/vsphere_vm_clone_spec.rb
@@ -284,6 +284,46 @@ describe Chef::Knife::VsphereVmClone do
             subject.run
           end
         end
+
+        context 'that provides customization domain' do
+          before do
+            subject.config[:customization_domain] = 'example.com'
+          end
+
+          context 'matching customization spec' do
+            let(:identity) { { identification: { joinDomain: 'example.com' },
+                               licenseFilePrintData: { autoMode: true },
+                               userData: { fullName: 'Chefy McChef' },
+                               guiUnattended: { autoLogon: true,
+                                                password: { plainText: 'plaintextpassword'} } }
+            }
+
+            it 'successfully clones with joinDomain set to customization domain' do
+              expect(template).to receive(:CloneVM_Task).and_return(task)
+              expect(spec).to receive(:'identity=') do |args|
+                expect(args.identification.joinDomain).to eq('example.com')
+              end
+              subject.run
+            end
+          end
+
+          context 'not matching customization spec' do
+            let(:identity) { { identification: { joinDomain: 'example2.com' },
+                               licenseFilePrintData: { autoMode: true },
+                               userData: { fullName: 'Chefy McChef' },
+                               guiUnattended: { autoLogon: true,
+                                                password: { plainText: 'plaintextpassword'} } }
+            }
+
+            it 'successfully clones with joinDomain set to customization domain' do
+              expect(template).to receive(:CloneVM_Task).and_return(task)
+              expect(spec).to receive(:'identity=') do |args|
+                expect(args.identification.joinDomain).to eq('example.com')
+              end
+              subject.run
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
If --cdomain matches what is in --cspec then use identification from the --cspec, else use --cdomain, and fall back to original behavior of using joinWorkgroup from the --cspec

### Description

Fixes an issue where --cdomain is ignored on Windows clones. If you specify --cdomain example.com and --cspec example, where the example customization spec contains joinDomain: 'example.com', then it is ignored and overridden with joinWorkgroup.

### Issues Resolved

<!--- List any existing issues this PR resolves--->

### Check List

- [x] All tests pass.
- [x] All style checks pass.
- [x] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable
