### PR TITLE
Add a nil check in the ipv4 address check.

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -23,6 +23,8 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
   AUTO_MAC = 'auto'
   # A NO IP for you to use!
   NO_IPS = ''
+  # a linklayer origin is an actual nic
+  ORIGIN_IS_REAL_NIC = 'linklayer'.freeze
 
   include Chef::Knife::WinrmBase
   include CustomizationHelper
@@ -424,8 +426,13 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     # Multiple reboots occur during guest customization in which a link-local
     # address is assigned. As such, we need to wait until a routable IP address
     # becomes available. This is most commonly an issue with Windows instances.
-    sleep 2 while (vm.guest.net[bootstrap_nic_index].ipConfig.ipAddress.detect { |addr| IPAddr.new(addr.ipAddress).ipv4? }.nil? || vm.guest.net[bootstrap_nic_index].ipConfig.ipAddress.detect { |addr| IPAddr.new(addr.ipAddress).ipv4? }.origin == 'linklayer')
+    sleep 2 while vm_is_waiting_for_ip?(vm)
     vm.guest.net[bootstrap_nic_index].ipAddress.detect { |addr| IPAddr.new(addr).ipv4? }
+  end
+
+  def vm_is_waiting_for_ip?(vm)
+    first_ip_address = vm.guest.net[bootstrap_nic_index].ipConfig.ipAddress.detect { |addr| IPAddr.new(addr.ipAddress).ipv4? }
+    first_ip_address.nil? || first_ip_address.origin == ORIGIN_IS_REAL_NIC
   end
 
   def guest_address(vm)

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -424,7 +424,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     # Multiple reboots occur during guest customization in which a link-local
     # address is assigned. As such, we need to wait until a routable IP address
     # becomes available. This is most commonly an issue with Windows instances.
-    sleep 2 while vm.guest.net[bootstrap_nic_index].ipConfig.ipAddress.detect { |addr| IPAddr.new(addr.ipAddress).ipv4? }.origin == 'linklayer'
+    sleep 2 while (vm.guest.net[bootstrap_nic_index].ipConfig.ipAddress.detect { |addr| IPAddr.new(addr.ipAddress).ipv4? }.nil? || vm.guest.net[bootstrap_nic_index].ipConfig.ipAddress.detect { |addr| IPAddr.new(addr.ipAddress).ipv4? }.origin == 'linklayer')
     vm.guest.net[bootstrap_nic_index].ipAddress.detect { |addr| IPAddr.new(addr).ipv4? }
   end
 


### PR DESCRIPTION
Sometimes in vsphere 6 the address setup on VMs is sluggish and the first address ends up being nil, this makes it so it doesn't crash testing if it's linklayer before it's fully initialized.

Signed-off-by: Scott Hain <shain@chef.io>

### Issues Resolved

<!--- List any existing issues this PR resolves--->

### Check List

- [ ] All tests pass.
- [ ] All style checks pass.
- [ ] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable
