### PR TITLE
Add datastore info to output

### DIFF
--- a/lib/chef/knife/vsphere_vm_disk_list.rb
+++ b/lib/chef/knife/vsphere_vm_disk_list.rb
@@ -27,8 +27,9 @@ class Chef::Knife::VsphereVmDiskList < Chef::Knife::BaseVsphereCommand
     end
 
     disks.each do |disk|
-      puts '%3d %20s %s' % [disk.unitNumber,
+      puts '%3d %20s %20s %s' % [disk.unitNumber,
                             disk.deviceInfo.label,
+                            disk.backing.datastore.name,
                             Filesize.from("#{disk.capacityInKB} KiB").pretty]
     end
   end


### PR DESCRIPTION
### Description

Adds datastore information to vm disk list output

### Issues Resolved

381

### Check List

- [o ] All tests pass.
- [? ] All style checks pass.
- [ No] Functionality includes testing.
- [ No] Functionality has been documented in the README if applicable
