### PR TITLE
Update vsphere_vm_delete.rb

### DIFF
--- a/lib/chef/knife/vsphere_vm_delete.rb
+++ b/lib/chef/knife/vsphere_vm_delete.rb
@@ -70,8 +70,7 @@ class Chef::Knife::VsphereVmDelete < Chef::Knife::BaseVsphereCommand
       vmname = config[:chef_node_name] if config[:chef_node_name]
       destroy_item(Chef::Node, vmname, 'node')
       destroy_item(Chef::ApiClient, vmname, 'client')
-    else
-      puts "Corresponding node and client for the #{vmname} server were not deleted and remain registered with the Chef Server"
+      puts "Corresponding node and client for the #{vmname} server were deleted and unregistered with the Chef Server"
     end
   end
 end


### PR DESCRIPTION
### Description

Puts should tell when something has executed. I moved the puts out of the purge loop because for example, if someone is not using Chef and only using this library to delete a vm in vCenter, it is giving an incorrect output.

### Issues Resolved

If you are not using Chef, you still get the output as if a node still exists in chef when deleting a VM from vCenter.

### Check List

- [x] All tests pass.
- [x] All style checks pass.
- [x] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable
