### PR TITLE
Handle the nicsettingmismatch error on clone

### DIFF
--- a/spec/vsphere_vm_clone_spec.rb
+++ b/spec/vsphere_vm_clone_spec.rb
@@ -126,6 +126,22 @@ describe Chef::Knife::VsphereVmClone do
     end
   end
 
+  context 'error handling' do
+    include_context 'basic_setup'
+
+    context 'user attempts to clone a box with the wrong number of nics configured' do
+      it 'should provide a helpful message' do
+        expect(template).to receive(:CloneVM_Task).and_return(task)
+        expect(task).to receive(:wait_for_completion) {
+          fault = RbVmomi::VIM::NicSettingMismatch.new(numberOfNicsInVM: 1, numberOfNicsInSpec: 2)
+          raise RbVmomi::Fault.new('fault.NicSettingMismatch.summary', fault)
+        }
+        expect { subject.run }.to raise_error SystemExit
+
+      end
+    end
+  end
+
   context 'customizations' do
     include_context 'basic_setup'
 


### PR DESCRIPTION
A common error happens when someone clones a template with multiple NICs
but doesn't give us enough IPs to assign, so they get a rather unhelpful
error message. This catches it and turns it into something helpful.

### Description

<!--- Describe what this change achieves--->

### Issues Resolved

<!--- List any existing issues this PR resolves--->

### Check List

- [x] All tests pass.
- [x] All style checks pass.
- [x] Functionality includes testing.
- [x] Functionality has been documented in the README if applicable
