### PR TITLE
Snapshot Changes: new option to input snapshot description during snapshot creation and addition of timestamp to snapshot listing.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 knife-vsphere changelog
 ----------------------
-2.0.2   bseeto  - Add snapshot creation timestamp to snapshot listing.
-                - Add option "--snapshot-descr DESCR" to allow users to add a
-				  description when creating a snapshot.
+2.0.2   nammiesgal - Add snapshot creation timestamp to snapshot listing.
+                   - Add option "--snapshot-descr DESCR" to allow users to add a 
+				   description when creating a snapshot.
 2.0.1   petermccool - Add datastore output to disk list
 			  mheidenr    - Fix vm migrate and refactor
 				scotthain   - Error checking when looking up address in clone

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 knife-vsphere changelog
 ----------------------
+2.0.2   bseeto  - Add snapshot creation timestamp to snapshot listing.
+                - Add option "--snapshot-descr DESCR" to allow users to add a
+				  description when creating a snapshot.
 2.0.1   petermccool - Add datastore output to disk list
 			  mheidenr    - Fix vm migrate and refactor
 				scotthain   - Error checking when looking up address in clone

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# knife vSphere
+﻿# knife vSphere
 
 [![Gem Version](https://badge.fury.io/rb/knife-vsphere.svg)](https://rubygems.org/gems/knife-vsphere)
 [![Build Status](https://travis-ci.org/chef-partners/knife-vsphere.svg?branch=master)](https://travis-ci.org/chef-partners/knife-vsphere)
@@ -434,7 +434,7 @@ Manages the snapshots for an existing VM, allowing for creation, removal, and
 reverting of snapshots.
 
 ```bash
---list            - List the current tree of snapshots
+--list            - List the current tree of snapshots and include snapshot creation timestamp
 --create SNAPSHOT - Create a new snapshot off of the current snapshot
 --remove SNAPSHOT - Remove a named snapshot.
 --revert SNAPSHOT - Revert to a named snapshot.
@@ -444,6 +444,7 @@ reverting of snapshots.
 --find            - Find the VM instead of specifying the folder with -F
 --dump-memory     - Dump the memory when creating the snapshot (default: false)
 --quiesce         - Quiesce the VM before snapshotting (default: false)
+--snapshot-descr DESCR - Include a description when creating a snapshot 
 ```
 
 ## `knife vsphere vm cdrom`

--- a/lib/chef/knife/vsphere_vm_snapshot.rb
+++ b/lib/chef/knife/vsphere_vm_snapshot.rb
@@ -59,7 +59,12 @@ class Chef::Knife::VsphereVmSnapshot < Chef::Knife::BaseVsphereCommand
          boolean: true,
          description: 'Quiesce the VM prior to snapshotting',
          default: false
-
+         
+  option :snapshot_description,
+    	 long: '--snapshot-descr DESCR',
+         description: 'Snapshot description',
+         default: ' '
+       
   def run
     $stdout.sync = true
 
@@ -94,7 +99,7 @@ class Chef::Knife::VsphereVmSnapshot < Chef::Knife::BaseVsphereCommand
 
     if get_config(:create_new_snapshot)
       snapshot_task = vm.CreateSnapshot_Task(name: get_config(:create_new_snapshot),
-                                             description: '',
+                                             description: get_config(:snapshot_description),
                                              memory: get_config(:dump_memory),
                                              quiesce: get_config(:quiesce))
       snapshot_task = snapshot_task.wait_for_completion if get_config(:wait)
@@ -142,12 +147,13 @@ class Chef::Knife::VsphereVmSnapshot < Chef::Knife::BaseVsphereCommand
   end
 
   def display_node(node, current, shift = 1)
+    descr = node.name + " " + node.createTime.iso8601()	
     out = ''
     out << '+--' * shift
     if node.snapshot == current
-      out << "#{ui.color(node.name, :cyan)}" << "\n"
+      out << "#{ui.color(descr, :cyan)}" << "\n"
     else
-      out << "#{node.name}" << "\n"
+      out << "#{descr}" << "\n"
     end
     unless node.childSnapshotList.empty?
       node.childSnapshotList.each { |item| out << display_node(item, current, shift + 1) }

--- a/lib/chef/knife/vsphere_vm_snapshot.rb
+++ b/lib/chef/knife/vsphere_vm_snapshot.rb
@@ -63,7 +63,7 @@ class Chef::Knife::VsphereVmSnapshot < Chef::Knife::BaseVsphereCommand
   option :snapshot_description,
          long: '--snapshot-descr DESCR',
          description: 'Snapshot description',
-         default: ' '
+         default: ''
 
   def run
     $stdout.sync = true
@@ -151,9 +151,9 @@ class Chef::Knife::VsphereVmSnapshot < Chef::Knife::BaseVsphereCommand
     out = ''
     out << '+--' * shift
     if node.snapshot == current
-      out << ui.color(descr, :cyan) << "\n"
+      out << ui.color(descr, :cyan) << '\n'
     else
-      out << descr << "\n"
+      out << descr << '\n'
     end
     unless node.childSnapshotList.empty?
       node.childSnapshotList.each { |item| out << display_node(item, current, shift + 1) }

--- a/lib/chef/knife/vsphere_vm_snapshot.rb
+++ b/lib/chef/knife/vsphere_vm_snapshot.rb
@@ -151,9 +151,9 @@ class Chef::Knife::VsphereVmSnapshot < Chef::Knife::BaseVsphereCommand
     out = ''
     out << '+--' * shift
     if node.snapshot == current
-      out << "#{ui.color(descr.to_s, :cyan)}" << "\n"
+      out << ui.color(descr, :cyan) << "\n"
     else
-      out << "#{descr.to_s}" << "\n"
+      out << descr << "\n"
     end
     unless node.childSnapshotList.empty?
       node.childSnapshotList.each { |item| out << display_node(item, current, shift + 1) }

--- a/lib/chef/knife/vsphere_vm_snapshot.rb
+++ b/lib/chef/knife/vsphere_vm_snapshot.rb
@@ -59,12 +59,12 @@ class Chef::Knife::VsphereVmSnapshot < Chef::Knife::BaseVsphereCommand
          boolean: true,
          description: 'Quiesce the VM prior to snapshotting',
          default: false
-         
+
   option :snapshot_description,
-    	 long: '--snapshot-descr DESCR',
+         long: '--snapshot-descr DESCR',
          description: 'Snapshot description',
          default: ' '
-       
+
   def run
     $stdout.sync = true
 
@@ -147,13 +147,13 @@ class Chef::Knife::VsphereVmSnapshot < Chef::Knife::BaseVsphereCommand
   end
 
   def display_node(node, current, shift = 1)
-    descr = node.name + " " + node.createTime.iso8601()	
+    descr = node.name + ' ' + node.createTime.iso8601
     out = ''
     out << '+--' * shift
     if node.snapshot == current
-      out << "#{ui.color(descr, :cyan)}" << "\n"
+      out << "#{ui.color(descr.to_s, :cyan)}" << "\n"
     else
-      out << "#{descr}" << "\n"
+      out << "#{descr.to_s}" << "\n"
     end
     unless node.childSnapshotList.empty?
       node.childSnapshotList.each { |item| out << display_node(item, current, shift + 1) }

--- a/lib/knife-vsphere/version.rb
+++ b/lib/knife-vsphere/version.rb
@@ -1,5 +1,5 @@
 # The main knife-vsphere module.
 module KnifeVsphere
   # The version of this gem.
-  VERSION = '2.0.1'
+  VERSION = '2.0'
 end

--- a/lib/knife-vsphere/version.rb
+++ b/lib/knife-vsphere/version.rb
@@ -1,5 +1,5 @@
 # The main knife-vsphere module.
 module KnifeVsphere
   # The version of this gem.
-  VERSION = '2.0'
+  VERSION = '2.0.1'
 end


### PR DESCRIPTION
### Description

<!--- Describe what this change achieves--->
I have made 2 changes to vsphere_vm_snapshot.rb
1) Added extra option when performing a snapshot create to allow users to add in a snapshot description.  Currently, the code hardcodes the snapshot description to empty string which I believe is inflexible as users would like the ability to enter a snapshot description to describe the snapshot they have just created.
2) Added snapshot creation timestamp to the snapshot listing tree.  This allows the user to view their list of snapshots along with when each snapshot was created.  Thus giving users more detail of their snapshots.
### Issues Resolved

<!--- List any existing issues this PR resolves--->

### Check List

- [ ] All tests pass.
- [ ] All style checks pass.
- [ ] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable
