### PR TITLE
Proceed to bootstrap if node exists.

### DIFF
--- a/knife-vsphere.gemspec
+++ b/knife-vsphere.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('netaddr', ['~> 1.5'])
   s.add_dependency('rbvmomi', ['~> 1.8'])
   s.add_dependency('filesize', ['~> 0.1.1'])
+  s.add_dependency('chef-vault', ['>= 2.6.0'])
 
   s.add_development_dependency('byebug')
   s.add_development_dependency('chef', ['>= 11.0'])

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -382,6 +382,8 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
       fault = e.fault
       if fault.class == RbVmomi::VIM::NicSettingMismatch
         abort "There is a mismatch in the number of NICs on the template (#{fault.numberOfNicsInVM}) and what you've passed on the command line with --cips (#{fault.numberOfNicsInSpec}). The VM has been cloned but not customized."
+      elsif fault.class == RbVmomi::VIM::DuplicateName
+        ui.info "VM already exists, proceeding to bootstrap"
       else
         raise e
       end
@@ -398,7 +400,11 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
     if get_config(:power) || get_config(:bootstrap)
       vm = find_in_folder(dest_folder, RbVmomi::VIM::VirtualMachine, vmname) ||
            fatal_exit("VM #{vmname} not found")
-      vm.PowerOnVM_Task.wait_for_completion
+      begin
+        vm.PowerOnVM_Task.wait_for_completion
+      rescue RbVmomi::Fault => e
+        raise e unless e.fault.class == RbVmomi::VIM::InvalidPowerState # Ignore if it's already turned on
+      end
       puts "Powered on virtual machine #{vmname}"
     end
 

--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -383,7 +383,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
       if fault.class == RbVmomi::VIM::NicSettingMismatch
         abort "There is a mismatch in the number of NICs on the template (#{fault.numberOfNicsInVM}) and what you've passed on the command line with --cips (#{fault.numberOfNicsInSpec}). The VM has been cloned but not customized."
       elsif fault.class == RbVmomi::VIM::DuplicateName
-        ui.info "VM already exists, proceeding to bootstrap"
+        ui.info 'VM already exists, proceeding to bootstrap'
       else
         raise e
       end


### PR DESCRIPTION
Fixes #416. If the node exists in vsphere, proceed to bootstrap rather
    than bail out.

    Chef will still prompt the user to overwrite the node and client, so if
    for some reason this wasn't intentional, there's a safe way to bail.

    I'd considered making this an option but thinking to the way I use this
    command it's usually going to be the desired approach. In fact I needed
    it twice this morning, leading to me making the change.