### PR TITLE
Move vsphere vm find to use container view

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,8 @@ Style/ClassAndModuleChildren:
   Enabled: false
 Style/Documentation:
   Enabled: false
+Style/SafeNavigation:
+  Enabled: false
 
 Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.

--- a/README.md
+++ b/README.md
@@ -183,21 +183,11 @@ is currently displayed.
 
 ## `knife vsphere vm find`
 
-Search for Virtual Machines matching criteria in the specified pool and
-display selected fields
-
-Required arguments:
-
-```bash
---pool POOL_NAME           -Name of the pool to search in
-```
-
-OPTIONS:
-```bash
---pool-path                  do not search for pool name,pool argument is an exact path
-```
+Search for Virtual Machines matching criteria and display selected fields
 
 CRITERIA:
+Note that _all_ criteria must be satisfied for the VM to be returned
+
 ```bash
 --match-ip IP                match ip
 --match-name VMNAME          match name
@@ -213,7 +203,8 @@ FIELDS:
 --cpu                        Show cpu
 --cpu-hot-add-enabled        Show cpu hot add enabled flag
 --esx-disk                   Show esx disks
---full-path                  Show full path
+--full-path                  Show full folder path to the VM
+--short-path                 Show the enclosing folder name
 --hostname                   show hostname
 --host_name                  Show name of the VM's host
 --ip                         Show primary ip
@@ -229,7 +220,7 @@ FIELDS:
 Example:
 
 ```bash
-$ knife vsphere vm find --snapshots --full-path --pool XXX-YYYY --cpu --ram --esx-disk \
+$ knife vsphere vm find --snapshots --full-path --cpu --ram --esx-disk \
     --os-disk --os --match-name my_machine_1 --alarms --tools --ip --ips \
     --match-ip 123 --match-tools toolsOk
 ```

--- a/spec/vsphere_vm_find_spec.rb
+++ b/spec/vsphere_vm_find_spec.rb
@@ -1,159 +1,167 @@
 require 'spec_helper'
 require 'chef/knife/vsphere_vm_find'
 
+class Hash
+  # An artifact of me using hashes to represent the VM -- the method needs to be there to mock
+  def obj
+    raise "You shouldn't be calling me"
+  end
+end
+
 describe Chef::Knife::VsphereVmFind do
   subject { described_class.new }
 
-  let(:compute_resource) { double('ClusterComputeResource', resourcePool: the_pool) }
-  let(:the_pool) { double('VmList', vm: vmlist) }
   let(:ui) { double('ChefUI') }
 
+  let(:vm1) { { 'name' => 'myvm', 'runtime.powerState' => 'poweredOn' } }
+  let(:vm2) { { 'name' => 'another', 'runtime.powerState' => 'poweredOn' } }
+
+  let(:expected_properties) { [ 'name', 'runtime.powerState' ] }
+  let(:returned_vms) { [ vm1 ] }
+
   before do
-    subject.config[:pool] = 'testpool'
-    subject.config[:matchname] = 'myvm'
+    expect(subject).to receive(:ui).and_return(ui)
+    expect(subject).to receive(:get_all_vm_objects).with(properties: expected_properties).and_return(returned_vms)
   end
 
-  context 'asking for the deprecated ips and networks' do
-    before do
-      subject.config[:ips] = true
-    end
+  context 'matching vm names' do
+    let(:returned_vms) { [ vm1, vm2 ] }
 
-    it 'tells the user to use --networks' do
-      expect(subject).to receive(:abort).and_raise(SystemExit)
-      expect { subject.run }.to raise_error(SystemExit)
-    end
-  end
+    it 'returns only matching vms' do
+      subject.config[:matchname] = 'myvm'
 
-
-  context 'simply looking for a vm' do
-    include_context 'basic_setup'
-
-    let(:runtime) { double('RunTime', powerState: 'poweredOn') }
-    let(:parent) { double('ManagedEntity', name: 'vms') }
-    let(:guest) { double('Guest', guestFullName: 'Windows 2000 Professional') }
-    let(:vm1) { double('VM', runtime: runtime, name: 'myvm', guest: guest, parent: parent) }
-    let(:vm2) { double('VM', name: 'anothervm') }
-
-    let(:vmlist) { [ vm1, vm2 ] }
-
-    before do
-      expect(subject).to receive(:ui).and_return(ui)
-      allow(subject).to receive(:traverse_folders_for_pool_clustercompute).and_return(compute_resource)
-    end
-
-    it 'returns the one vm' do
-      expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'folder'=>'vms'}])
+      expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm'}])
 
       subject.run
     end
+  end
 
-    context 'asking for a hostname' do
+  context 'matching ips' do
+    let(:returned_vms) { [ vm1, vm2 ] }
+    let(:expected_properties) { [ 'name', 'runtime.powerState', 'guest.ipAddress' ] }
+    let(:vm1) { { 'name' => 'myvm', 'runtime.powerState' => 'poweredOn', 'guest.ipAddress' => '1.2.3.4'} }
+    let(:vm2) { { 'name' => 'another', 'runtime.powerState' => 'poweredOn', 'guest.ipAddress' => '4.5.6.7' } }
+
+    it 'returns only matching vms' do
+      subject.config[:matchip] = '1.2.3'
+
+      expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'ip' => '1.2.3.4'}])
+
+      subject.run
+    end
+  end
+
+  context 'matching ips and names' do
+    let(:returned_vms) { [ vm1, vm2 ] }
+    let(:expected_properties) { [ 'name', 'runtime.powerState', 'guest.ipAddress' ] }
+    let(:vm1) { { 'name' => 'myvm', 'runtime.powerState' => 'poweredOn', 'guest.ipAddress' => '1.2.3.4'} }
+    let(:vm2) { { 'name' => 'another', 'runtime.powerState' => 'poweredOn', 'guest.ipAddress' => '4.5.6.7' } }
+
+    it 'returns only the vm that matches both' do
+      subject.config[:matchip] = '4'
+      subject.config[:matchname] = 'myvm'
+
+      expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'ip' => '1.2.3.4'}])
+
+      subject.run
+    end
+  end
+
+  context 'asking for a hostname' do
+    let(:expected_properties) { [ 'name', 'runtime.powerState', 'guest.hostName' ] }
+    let(:vm1) { { 'name' => 'myvm', 'runtime.powerState' => 'poweredOn', 'guest.hostName' => 'thehost.example.com' } }
+
+    before do
+      subject.config[:hostname] = true
+    end
+
+    it 'includes the hostname in the output' do
+      expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'hostname'=>'thehost.example.com'}])
+
+      subject.run
+    end
+  end
+
+  context 'asking for the name of the guests host' do
+    let(:expected_properties) { [ 'name', 'runtime.powerState', 'summary.runtime.host' ] }
+    let(:vm1) { { 'name' => 'myvm', 'runtime.powerState' => 'poweredOn', 'summary.runtime.host' => OpenStruct.new(name: 'host1') } }
+
+    before do
+      subject.config[:host_name] = true
+    end
+    it 'includes the host_name in the output' do
+      expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'host_name'=>'host1'}])
+
+      subject.run
+    end
+  end
+
+  context 'asking for the networks' do
+    let(:expected_properties) { [ 'name', 'runtime.powerState', 'guest.net' ] }
+    let(:vm1) { { 'name' => 'myvm', 'runtime.powerState' => 'poweredOn', 'guest.net' => networks } }
+
+    before do
+      subject.config[:networks] = true
+    end
+
+    context 'a single network' do
+      let(:net1) { double('Network', network: 'VLAN1', ipConfig: ipconfig1) }
+      let(:ipconfig1) { double('IPconfig', ipAddress: [ip1] ) }
+      let(:ip1) { double('IPAddress', ipAddress: '1.2.3.4', prefixLength: '24')}
+      let(:networks) { [ net1 ] }
+
       before do
-        subject.config[:hostname] = true
-        allow(guest).to receive(:hostName).and_return('thehost.example.com')
       end
 
-      it 'includes the hostname in the output' do
-        expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'folder'=>'vms', 'hostname'=>'thehost.example.com'}])
-
+      it 'returns the network and IP' do
+        expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'networks' => [ { 'name' => 'VLAN1', 'ip' => '1.2.3.4', 'prefix' => '24'}] }])
         subject.run
       end
     end
 
-    context 'asking for the name of the guests host' do
-      before do
-        subject.config[:host_name] = true
-        allow(vm1).to receive_message_chain(:summary, :runtime, :host, :name) { 'host1' }
-      end
-      it 'includes the host_name in the output' do
-        expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'folder'=>'vms', 'host_name'=>'host1'}])
+    context 'multiple networks' do
+    end
+  end
 
+  context 'asking for the full path' do
+    let(:parent1) { double('Parent', name: 'vms', parent: nil) }
+    let(:parent2) { double('Parent', name: 'projectX', parent: parent1) }
+
+    before do
+      subject.config[:full_path] = true
+      allow(vm1).to receive(:obj).and_return(vmobj)
+    end
+
+    context 'with one path element' do
+      let(:vmobj) { double('FullVMObject', parent: parent1) }
+
+      it 'returns the name of the folder' do
+        expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'folder'=>'vms'}])
         subject.run
       end
     end
 
-    context 'asking for the primary ip' do
-      let(:ip) { '1.2.3.4' }
+    context 'with a nested folder' do
+      let(:vmobj) { double('FullVMObject', parent: parent2) }
 
-      before do
-        subject.config[:ip] = true
-        allow(guest).to receive(:ipAddress).and_return(ip)
-      end
-
-      it 'returns the ip' do
-        expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'folder'=>'vms', 'ip'=>ip}])
+      it 'returns the name of the folder' do
+        expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'folder'=>'vms/projectX'}])
         subject.run
       end
     end
+  end
 
-    context 'asking for the networks' do
-      before do
-        subject.config[:networks] = true
-        expect(guest).to receive(:net).and_return(networks)
-      end
-
-      context 'a single network' do
-        let(:net1) { double('Network', network: 'VLAN1', ipConfig: ipconfig1) }
-        let(:ipconfig1) { double('IPconfig', ipAddress: [ip1] ) }
-        let(:ip1) { double('IPAddress', ipAddress: '1.2.3.4', prefixLength: '24')}
-        let(:networks) { [ net1 ] }
-
-        before do
-          allow(vm1).to receive_message_chain(:summary, :runtime, :host, :name) { 'host1' }
-        end
-
-        it 'returns the network and IP' do
-          expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'folder'=>'vms', 'networks' => [ { 'name' => 'VLAN1', 'ip' => '1.2.3.4', 'prefix' => '24'}] }])
-          subject.run
-        end
-      end
-
-      context 'multiple networks' do
-      end
+  context 'asking for the os disks' do
+    let(:disk1) { double('Disk', capacity: 10000 * 1024 * 1024, diskPath: 'disk1', freeSpace: 500 * 1024 * 1024)}
+    let(:expected_properties) { [ 'name', 'runtime.powerState', 'guest.disk' ] }
+    let(:vm1) { { 'name' => 'myvm', 'runtime.powerState' => 'poweredOn', 'guest.disk' => [disk1] } }
+    before do
+      subject.config[:os_disk] = true
     end
 
-    context 'asking for the full path' do
-      let(:parent1) { double('Parent', name: 'vms', parent: nil) }
-      let(:parent2) { double('Parent', name: 'projectX', parent: parent1) }
-
-      before do
-        subject.config[:full_path] = true
-      end
-
-      context 'with one path element' do
-        before do
-          allow(vm1).to receive(:parent).and_return(parent1)
-        end
-
-        it 'returns the name of the folder' do
-          expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'folder'=>'vms'}])
-          subject.run
-        end
-      end
-
-      context 'with a nested folder' do
-        before do
-          allow(vm1).to receive(:parent).and_return(parent2)
-        end
-
-        it 'returns the name of the folder' do
-          expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'folder'=>'vms/projectX'}])
-          subject.run
-        end
-      end
-    end
-
-    context 'asking for the os disks' do
-      let(:disk1) { double('Disk', capacity: 10000 * 1024 * 1024, diskPath: 'disk1', freeSpace: 500 * 1024 * 1024)}
-      before do
-        subject.config[:os_disk] = true
-        allow(guest).to receive(:disk).and_return([disk1])
-      end
-
-      it 'returns the disks' do
-        expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'folder'=>'vms', 'disks' => [ { 'name' =>'disk1', 'capacity' => 10000, 'free' => 500 } ]}])
-        subject.run
-      end
+    it 'returns the disks' do
+      expect(ui).to receive(:output).with([{'state'=>'on', 'name'=>'myvm', 'disks' => [ { 'name' =>'disk1', 'capacity' => 10000, 'free' => 500 } ]}])
+      subject.run
     end
   end
 end


### PR DESCRIPTION
Use the container view api in vsphere to retrieve only the info we need
about the VMs so we can search more quickly.

This introduces a breaking change in that the folder is no longer
default. You need to use --short-path to get the folder name.
