### PR TITLE
Fix template missing error message h/t aaronkjones

### DIFF
--- a/lib/chef/knife/vsphere_vm_clone.rb
+++ b/lib/chef/knife/vsphere_vm_clone.rb
@@ -358,7 +358,7 @@ class Chef::Knife::VsphereVmClone < Chef::Knife::BaseVsphereCommand
 
     dc = datacenter
 
-    src_vm = get_vm_by_name(get_config(:source_vm), get_config(:folder)) || fatal_exit("Could not find template #{vmname}")
+    src_vm = get_vm_by_name(get_config(:source_vm), get_config(:folder)) || fatal_exit("Could not find template #{get_config(:source_vm)}")
 
     create_delta_disk(src_vm) if get_config(:linked_clone)
 


### PR DESCRIPTION
Was printing the name of the VM when it should have been the template.

Fixes #435, h/t @aaronkjones

### Check List

- [x] All tests pass.
- [x] All style checks pass.
- [x] Functionality includes testing.
- [x] Functionality has been documented in the README if applicable
