### PR TITLE
Require Chef 13+ as a dev dep

### DIFF
--- a/knife-vsphere.gemspec
+++ b/knife-vsphere.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('chef-vault', ['>= 2.6.0'])
 
   s.add_development_dependency('byebug')
-  s.add_development_dependency('chef', ['>= 11.0'])
+  s.add_development_dependency('chef', ['>= 13.0'])
   s.add_development_dependency('rake')
   s.add_development_dependency('rb-readline')
   s.add_development_dependency('rspec')


### PR DESCRIPTION
Chef 11 is beyond EOL at this point

Signed-off-by: Tim Smith <tsmith@chef.io>