### PR TITLE
Remove unused fog require

### DIFF
--- a/lib/chef/knife/base_vsphere_command.rb
+++ b/lib/chef/knife/base_vsphere_command.rb
@@ -25,7 +25,6 @@ class Chef
       deps do
         require 'chef/knife/bootstrap'
         Chef::Knife::Bootstrap.load_deps
-        require 'fog'
         require 'socket'
         require 'net/ssh/multi'
         require 'readline'


### PR DESCRIPTION
I can't see anywhere this is actually used and it's not in the gemspec

Signed-off-by: Tim Smith <tsmith@chef.io>