### PR TITLE
Updated rubies for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.7
   - 2.4.4
   - 2.5.1
+  - 2.6
+  - ruby-head
 script:
   - bundle exec rake spec
   - bundle exec rake yard


### PR DESCRIPTION
Chef 14 needs at least 2.4.0, and we should test 2.6, and ruby-head.

Signed-off-by: JJ Asghar <jj@chef.io>